### PR TITLE
Set spoilers to engage at 70% RPM instead of 70% throttle.

### DIFF
--- a/A-4E-C/Cockpit/Scripts/Systems/spoilers.lua
+++ b/A-4E-C/Cockpit/Scripts/Systems/spoilers.lua
@@ -69,7 +69,7 @@ function update()
     local throttle = sensor_data.getThrottleLeftPosition()
 
 
-    if get_elec_retraction_release_ground() and throttle < 0.7 and SPOILER_ARMED and get_elec_mon_dc_ok() then
+    if get_elec_retraction_release_ground() and throttle < 0.34 and SPOILER_ARMED and get_elec_mon_dc_ok() then
         SPOILER_TARGET = 1
     else
         SPOILER_TARGET = 0


### PR DESCRIPTION
70% throttle translate to about 85% RPM and 34% of throttle to 70% RPM.
This fixes issue #416.