### PR TITLE
Fix issue #392 MCL course-needle offset on HMAS Melbourne

### DIFF
--- a/A-4E-C/Cockpit/Scripts/Nav/ara63_mcl.lua
+++ b/A-4E-C/Cockpit/Scripts/Nav/ara63_mcl.lua
@@ -49,7 +49,7 @@ local icls_to_object_id = {}
 local beacon_offsets = {
     ["Stennis"]  = {18.0, 13.0, 9.0},
     ["hmas_melbourne_wip"]  = {9.0, 7.5, 5.5},
-	["hmas_melbourne"]  = {9.0, 7.5, 5.5},
+    ["hmas_melbourne"]  = {9.0, 7.5, 5.5},
 }
 
 -------------------------------------------

--- a/A-4E-C/Cockpit/Scripts/Nav/ara63_mcl.lua
+++ b/A-4E-C/Cockpit/Scripts/Nav/ara63_mcl.lua
@@ -44,12 +44,11 @@ local icls_to_object_id = {}
 -- Beacon offset in format [x offset (forward-backward), z offset(left-right), deck angle]
 --
 -- deck angle of Melbourne found at https://www.navy.gov.au/history/angled-flight-deck
--- x and z are guesstimates
 
 local beacon_offsets = {
-    ["Stennis"]  = {18.0, 13.0, 9.0},
-    ["hmas_melbourne_wip"]  = {9.0, 7.5, 5.5},
-    ["hmas_melbourne"]  = {9.0, 7.5, 5.5},
+    ["Stennis"] = {18.0, 13.0, 9.0},
+    ["hmas_melbourne_wip"] = {60.0, 0.0, 5.5},
+    ["hmas_melbourne"] = {60.0, 0.0, 5.5},
 }
 
 -------------------------------------------

--- a/A-4E-C/Cockpit/Scripts/Nav/ara63_mcl.lua
+++ b/A-4E-C/Cockpit/Scripts/Nav/ara63_mcl.lua
@@ -41,6 +41,17 @@ local ils_data, marker_data = get_ils_data_in_format()
 local tacan_to_object_id = {}
 local icls_to_object_id = {}
 
+-- Beacon offset in format [x offset (forward-backward), z offset(left-right), deck angle]
+--
+-- deck angle of Melbourne found at https://www.navy.gov.au/history/angled-flight-deck
+-- x and z are guesstimates
+
+local beacon_offsets = {
+    ["Stennis"]  = {18.0, 13.0, 9.0},
+    ["hmas_melbourne_wip"]  = {9.0, 7.5, 5.5},
+	["hmas_melbourne"]  = {9.0, 7.5, 5.5},
+}
+
 -------------------------------------------
 --           FILE VARIABLES
 -------------------------------------------
@@ -294,11 +305,27 @@ function fetch_current_ils()
             --This is really lazy, I just couldn't
             --be bothered to create another 2d rotation
             --function.
-            x_dir.x = -x_dir.x * 18.0
-            x_dir.z = -x_dir.z * 18.0
+            local x_offset = 18.0
+            local z_offset = 13.0
 
-            z_dir.x = z_dir.x * 13.0
-            z_dir.z = z_dir.z * 13.0
+            -- Nimitz class deck angle = 9.0 deg
+            -- Majestic class deck angle = 5.5 deg
+            local deck_angle = 9.0
+			
+            local ship_os = beacon_offsets[object_data.type]
+            -- override the default values if ship type found
+            if ship_os then
+                --print_message_to_user("x= "..tostring(ship_os[1]).." z= "..tostring(ship_os[2]).." angle= "..tostring(ship_os[3]))
+                x_offset = ship_os[1]
+                z_offset = ship_os[2]
+                deck_angle = ship_os[3]
+            end
+			
+            x_dir.x = -x_dir.x * x_offset
+            x_dir.z = -x_dir.z * x_offset
+
+            z_dir.x = z_dir.x * z_offset
+            z_dir.z = z_dir.z * z_offset
 
             x = x + x_dir.x + z_dir.x
             z = z + x_dir.z + z_dir.z
@@ -319,7 +346,7 @@ function fetch_current_ils()
                         y = y,
                         z = z, 
                     },
-                    direction = heading - 9,
+                    direction = heading - deck_angle,
                     frequency = 0,
                 },
 
@@ -330,7 +357,7 @@ function fetch_current_ils()
                         z = z,
                         
                     },
-                    direction = heading - 9,
+                    direction = heading - deck_angle,
                     frequency = 0,
                 },
             }

--- a/A-4E-C/Cockpit/Scripts/Systems/mission_utils.lua
+++ b/A-4E-C/Cockpit/Scripts/Systems/mission_utils.lua
@@ -116,6 +116,7 @@ function append_beacons_to_id(groups, tacan_to_id, icls_to_id)
             search_for_task_beacons(tasks, group_beacon_data)
         end
         local unit_id = value["units"][1]["unitId"]
+        local unit_type = value["units"][1]["type"]
 
         for i,unit in ipairs(group_beacon_data) do
             local unit_id_to_use = unit_id
@@ -128,21 +129,21 @@ function append_beacons_to_id(groups, tacan_to_id, icls_to_id)
             local table_to_use = tacan_to_id
 
             if unit.type == "icls" then
-                append_group_beacon_data(icls_to_id, unit.channel, unit_id_to_use, name, unit.callsign, false)
+                append_group_beacon_data(icls_to_id, unit.channel, unit_id_to_use, name, unit.callsign, false, unit_type)
             else
-                append_group_beacon_data(tacan_to_id, unit.channel, unit_id_to_use, name, unit.callsign, unit.air_to_air)
+                append_group_beacon_data(tacan_to_id, unit.channel, unit_id_to_use, name, unit.callsign, unit.air_to_air, unit_type)
             end
         end
     end
 end
 
-function append_group_beacon_data(t, channel, unit_id, name, callsign, air_to_air)
+function append_group_beacon_data(t, channel, unit_id, name, callsign, air_to_air, unit_type)
     if t[channel] == nil then
         t[channel] = {}
-        t[channel][1] = { id = unit_id, name = name, callsign = callsign, air_to_air = air_to_air }
+        t[channel][1] = { id = unit_id, name = name, callsign = callsign, air_to_air = air_to_air, type = unit_type }
     else
         local len = #t[channel]
-        t[channel][len+1] = { id = unit_id, name = name, callsign = callsign, air_to_air = air_to_air }
+        t[channel][len+1] = { id = unit_id, name = name, callsign = callsign, air_to_air = air_to_air, type = unit_type }
     end
 end
 


### PR DESCRIPTION
Propagate the ship type type from the mission description to the MCL handling.

There try to find the ship type in a table and get it's beacon offsets and flight deck angle.  If not found, use the Stennis data as default values.

Deck angle for HMAS Melbourne from  https://www.navy.gov.au/history/angled-flight-deck but seems a good match. The offsets are found experimentally and could be inaccurate.