### PR TITLE
Added MCL offset for HMS Hermes 1969 model

### DIFF
--- a/A-4E-C/Cockpit/Scripts/Nav/ara63_mcl.lua
+++ b/A-4E-C/Cockpit/Scripts/Nav/ara63_mcl.lua
@@ -43,12 +43,13 @@ local icls_to_object_id = {}
 
 -- Beacon offset in format [x offset (forward-backward), z offset(left-right), deck angle]
 --
--- deck angle of Melbourne found at https://www.navy.gov.au/history/angled-flight-deck
+-- deck angle of Melbourne and Hermes found in lua scripts for resp. ship mod
 
 local beacon_offsets = {
     ["Stennis"] = {18.0, 13.0, 9.0},
-    ["hmas_melbourne_wip"] = {60.0, 0.0, 5.5},
-    ["hmas_melbourne"] = {60.0, 0.0, 5.5},
+    ["hmas_melbourne_wip"] = {60.0, 0.0, 6.0},
+    ["hmas_melbourne"] = {60.0, 0.0, 6.0},
+    ["HERMES69"] = {45.0, 0.0, 9.0},
 }
 
 -------------------------------------------


### PR DESCRIPTION
Added entry for HMS Hermes (model 1969) in the table with beacon offsets for the MCL system.

Also updated the deck angle values for HMAS Melbourne.

Values taken from ship mod lua scripts (look for *RunwayAndRoutes.lua).