### PR TITLE
Unlimited fuel support

### DIFF
--- a/A-4E-C/ExternalFM/FM/FuelSystem2.cpp
+++ b/A-4E-C/ExternalFM/FM/FuelSystem2.cpp
@@ -130,6 +130,12 @@ void FuelSystem2::addFuel( double dm, bool wingFirst )
 
 void FuelSystem2::update( double dt )
 {
+	if(m_unlimited_fuel)
+	{
+		m_boostPumpPressure = true; //Cut the Fuel Boost light
+		return;
+	}
+
 	//The factor from the engine for transfer since all transfer relies on bleed,
 	//either directly to pressurise the tank or to spin a turbopump.
 	double rateFactor = transferRateFactor();

--- a/A-4E-C/ExternalFM/FM/FuelSystem2.h
+++ b/A-4E-C/ExternalFM/FM/FuelSystem2.h
@@ -47,6 +47,8 @@ public:
 	void update( double dt );
 	bool handleInput( int command, float value );
 
+	inline void setUnlimitedFuel( bool state );
+
 	inline bool hasFuel() const;
 	inline void updateMechPumpPressure();
 	inline double transferFuel( Tank from, Tank to, double dm );
@@ -79,6 +81,7 @@ public:
 	inline void setTankPos( Tank tank, const Vec3& pos ) { m_fuelPos[tank] = pos; }
 
 private:
+	bool m_unlimited_fuel = false;
 
 	double m_fuel[NUMBER_OF_TANKS] = { 0.0, 0.0, 0.0, 0.0, 0.0 };
 	double m_fuelPrevious[NUMBER_OF_TANKS] = { 0.0, 0.0, 0.0, 0.0, 0.0 };
@@ -109,6 +112,11 @@ private:
 	Scooter::Engine2& m_engine;
 	Scooter::AircraftState& m_state;
 };
+
+void FuelSystem2::setUnlimitedFuel( bool state )
+{
+	m_unlimited_fuel = state;
+}
 
 void FuelSystem2::setBoostPumpPower( bool power )
 {

--- a/A-4E-C/ExternalFM/FM/Scooter.cpp
+++ b/A-4E-C/ExternalFM/FM/Scooter.cpp
@@ -1262,3 +1262,8 @@ void ed_fm_set_immortal( bool value )
 	if ( value )
 		printf( "Nice try!\n" );
 }
+
+void ed_fm_unlimited_fuel( bool value )
+{
+	s_fuelSystem->setUnlimitedFuel(value);
+}

--- a/A-4E-C/ExternalFM/FM/Scooter.h
+++ b/A-4E-C/ExternalFM/FM/Scooter.h
@@ -264,4 +264,5 @@ extern "C"
 	ED_FM_API bool ed_fm_LERX_vortex_update(unsigned idx, LERX_vortex& out);
 
 	ED_FM_API void ed_fm_set_immortal( bool value );
+	ED_FM_API void ed_fm_unlimited_fuel( bool value );
 };


### PR DESCRIPTION
Solve #472 by:
- Catching the option activation in `Scooter.cpp` and reflecting it in `FuelSystem2.m_unlimited_fuel`
- If `m_unlimited_fuel `is true, bypassing the fuel update (and putting the `boostPumpPressure` to true to avoid the Fuel Boost warning turning on)

I would be glad to get feedback on these changes to see if they are appropriate. As it is my first PR, I don't know if you have a specific formatting style.