### PR TITLE
Fixed blinking in_range during test

### DIFF
--- a/A-4E-C/ExternalFM/FM/Interface.h
+++ b/A-4E-C/ExternalFM/FM/Interface.h
@@ -470,7 +470,9 @@ public:
 
 	inline void setInRange( bool inRange )
 	{
-		setParamNumber( m_inRange, (double)inRange );
+		if (getMasterTest() == false) {
+            setParamNumber(m_inRange, (double)inRange);
+        }	
 	}
 
 	inline void setFuelTransferCaution( bool caution )


### PR DESCRIPTION
Fixes #329 
Not sure if it is still needed, maybe you did not commit yet some changes.
Just check if master test is on before turning off/on the light to avoid conflict with the master test in avionics.