### PR TITLE
Add ready pre-contact binding

### DIFF
--- a/A-4E-C/Input/joystick/default.lua
+++ b/A-4E-C/Input/joystick/default.lua
@@ -24,6 +24,8 @@ join(res.keyCommands,{
     {down = Keys.ChangeCmsBurstInterval, value_down = 1,     name = _('Countermeasures Burst Interval'),              category = {_('Communications'), _('Kneeboard'), _('AN/ALE-29A Chaff Dispensing System')}},
     {down = Keys.ChangeCmsSalvos, value_down = 1,            name = _('Countermeasures Salvos'),                      category = {_('Communications'), _('Kneeboard'), _('AN/ALE-29A Chaff Dispensing System')}},
     {down = Keys.ChangeSalvoInterval, value_down = 1,        name = _('Countermeasures Salvo Interval'),              category = {_('Communications'), _('Kneeboard'), _('AN/ALE-29A Chaff Dispensing System')}},
+     -- A/A refueling
+    {down = iCommandPlaneRefuelingReadyPreContact, name = _('A/A refueling - "Ready for precontact" radio call'), category = _('Communications')},
 
     ---------------------------------------------
     -- Sensors ----------------------------------
@@ -614,7 +616,6 @@ join(res.keyCommands,{
     {down = Keys.AFCSHotasPath, up = Keys.AFCSHotasAltHdg,  name = _('AFCS Path Mode else Altitude + Heading (Warthog Throttle)'),      category = {_('Console Left'), _('AFCS Control Panel'), _('Special For Joystick')}},
     {down = Keys.AFCSHotasAlt, up = Keys.AFCSHotasAltHdg,   name = _('AFCS Altitude Mode else Altitude + Heading (Warthog Throttle)'),  category = {_('Console Left'), _('AFCS Control Panel'), _('Special For Joystick')}},
     {down = Keys.AFCSHotasEngage,                           name = _('AFCS Engage (Warthog Throttle)'),                                 category = {_('Console Left'), _('AFCS Control Panel'), _('Special For Joystick')}},
-
 })
 
 -- joystick axes 

--- a/A-4E-C/Input/keyboard/default.lua
+++ b/A-4E-C/Input/keyboard/default.lua
@@ -24,6 +24,8 @@ join(res.keyCommands,{
     {combos = {{key = '5', reformers = {'RShift','RAlt'}}},	down = Keys.ChangeCmsBurstInterval, value_down = 1,     name = _('Countermeasures Burst Interval'),              category = {_('Communications'), _('Kneeboard'), _('AN/ALE-29A Chaff Dispensing System')}},
     {combos = {{key = '6', reformers = {'RShift','RAlt'}}},	down = Keys.ChangeCmsSalvos, value_down = 1,            name = _('Countermeasures Salvos'),                      category = {_('Communications'), _('Kneeboard'), _('AN/ALE-29A Chaff Dispensing System')}},
     {combos = {{key = '7', reformers = {'RShift','RAlt'}}},	down = Keys.ChangeSalvoInterval, value_down = 1,        name = _('Countermeasures Salvo Interval'),              category = {_('Communications'), _('Kneeboard'), _('AN/ALE-29A Chaff Dispensing System')}},
+    -- A/A refueling
+    {down = iCommandPlaneRefuelingReadyPreContact, name = _('A/A refueling - "Ready for precontact" radio call'), category = _('Communications')},
 
     ---------------------------------------------
     -- Sensors ----------------------------------


### PR DESCRIPTION
Similar to what the F/A-18C has, which is the option to bind the "ready pre-contact" call to a key/button.

Very handy in VR!

![image](https://user-images.githubusercontent.com/53709079/192114770-e1edfd33-f08d-4329-a2cc-d81aa87c0228.png)
