### PR TITLE
Cpp warnings pass

### DIFF
--- a/A-4E-C/ExternalFM/FM/AeroElement.cpp
+++ b/A-4E-C/ExternalFM/FM/AeroElement.cpp
@@ -219,4 +219,6 @@ double Scooter::AeroControlElement::controlInput()
 		printf("ERROR: invalid control surface\n");
 		break;
 	}
+
+	return 0.0;
 }

--- a/A-4E-C/ExternalFM/FM/Axis.h
+++ b/A-4E-C/ExternalFM/FM/Axis.h
@@ -32,7 +32,7 @@ public:
 	inline void reset();
 	inline void slowReset();
 	inline void stop();
-	inline const double getValue() const;
+	inline double getValue() const;
 
 private:
 	double m_value = 0.0;
@@ -90,7 +90,7 @@ void Axis::keyDecrease()
 	m_slowReset = false;
 }
 
-const double Axis::getValue() const
+double Axis::getValue() const
 {
 	return m_value;
 }

--- a/A-4E-C/ExternalFM/FM/FM.vcxproj
+++ b/A-4E-C/ExternalFM/FM/FM.vcxproj
@@ -146,6 +146,7 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;ED_FM_TEMPLATE_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AssemblerOutput>All</AssemblerOutput>
       <AdditionalIncludeDirectories>$(ProjectDir);$(SolutionDir)</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/A-4E-C/ExternalFM/FM/Input.h
+++ b/A-4E-C/ExternalFM/FM/Input.h
@@ -212,7 +212,7 @@ public:
 	{
 		return m_throttleAxis.updateAxis(value);
 	}
-	inline const double& brakeLeft() const
+	inline double brakeLeft() const
 	{
 		if ( ! m_brakeAssist )
 			return m_leftBrakeAxis.getValue();
@@ -224,7 +224,7 @@ public:
 	{
 		return m_leftBrakeAxis.updateAxis(normalise(-value));
 	}
-	inline const double& brakeRight() const
+	inline double brakeRight() const
 	{
 		if ( ! m_brakeAssist )
 			return m_rightBrakeAxis.getValue();


### PR DESCRIPTION
Addressing a few C++ warnings.

* 90e815b is one that can lead to bugs and/or crashes (depending how lucky you get).
* 63b26ba is sanity (I assume all cases should already be covered).
* df09dda is maintenance (seems like an oversight).

I can split them up into multiple PRs if it's more convenient!