### PR TITLE
Weapons - Add Hydra Rockets

### DIFF
--- a/A-4E-C/A-4E-C.lua
+++ b/A-4E-C/A-4E-C.lua
@@ -80,9 +80,16 @@ local function get_outboard_weapons( side )
         { CLSID = "{AIM-9P5-ON-ADAPTER}",                    connector = rocketConnector, arg_value = 0.2 },  -- AIM-9P5
 	
         --ROCKETS--
-        --{ CLSID =   "{FD90A1DC-9147-49FA-BF56-CB83EF0BD32B}" }, -- LAU-61, M151 HE
-        --{ CLSID =   "{174C6E6D-0C3D-42ff-BCB3-0853CB371F5C}" }, -- LAU 68, MK5 HE
         { CLSID = "{F3EFE0AB-E91A-42D8-9CA2-B63C91ED570A}", connector = rocketConnector, arg_value = 0.2 }, -- LAU-10 Zuni
+
+        { CLSID = "{FD90A1DC-9147-49FA-BF56-CB83EF0BD32B}", connector = rocketConnector, arg_value = 0.2 }, -- LAU-61 Hydra M151 HE
+        { CLSID = "{3DFB7321-AB0E-11d7-9897-000476191836}", connector = rocketConnector, arg_value = 0.2 }, -- LAU-61 Hydra M156 WP
+
+        { CLSID = "{A021F29D-18AB-4d3e-985C-FC9C60E35E9E}", connector = rocketConnector, arg_value = 0.2 }, -- LAU 68 Hydra M151 HE
+        { CLSID = "{174C6E6D-0C3D-42ff-BCB3-0853CB371F5C}", connector = rocketConnector, arg_value = 0.2 }, -- LAU 68 Hydra Mk5 HEAT
+        { CLSID = "{4F977A2A-CD25-44df-90EF-164BFA2AE72F}", connector = rocketConnector, arg_value = 0.2 }, -- LAU 68 Hydra M156 WP
+        { CLSID = "{647C5F26-BDD1-41e6-A371-8DE1E4CC0E94}", connector = rocketConnector, arg_value = 0.2 }, -- LAU 68 Hydra M257 PI
+
         { CLSID = "{LAU3_FFAR_WP156}",                      connector = rocketConnector, arg_value = 0.2 }, -- LAU-3 FFAR WP156
         { CLSID = "{LAU3_FFAR_MK1HE}",                      connector = rocketConnector, arg_value = 0.2 }, -- LAU-3 FFAR Mk1 HE
         { CLSID = "{LAU3_FFAR_MK5HEAT}",                    connector = rocketConnector, arg_value = 0.2 }, -- LAU-3 FFAR Mk5 HEAT
@@ -108,7 +115,7 @@ local function get_outboard_weapons( side )
         { CLSID = "{AN-M88}" },                                 -- AN-M88 216 lb Fragmentation (47 lb Comp B)
 
         --SPECIAL--
-        { CLSID = "{647C5F26-BDD1-41e6-A371-8DE1E4CC0E94}"}, -- temporarily add M257 parachute flares until we can add: Mk-5 mod 7, Mk-6 mod 5, Mk-24 mod 2A, SUU-40/44
+        -- { CLSID = "{647C5F26-BDD1-41e6-A371-8DE1E4CC0E94}"}, -- temporarily add M257 parachute flares until we can add: Mk-5 mod 7, Mk-6 mod 5, Mk-24 mod 2A, SUU-40/44 -- moved to ROCKETS
 
 		-- SMOKE PODS --
 		{ CLSID = "{A4BCC903-06C8-47bb-9937-A30FEDB4E741}", connector = rocketConnector, arg_value = 0.2 }, -- Smoke Pod Red
@@ -126,8 +133,6 @@ local function get_outboard_weapons( side )
 	}
     return tbl
 end
-
-
 
 local function get_inboard_weapons( side )
     local rocketConnector = ""
@@ -149,25 +154,41 @@ local function get_inboard_weapons( side )
         { CLSID = "{DFT-150gal_EMPTY}" },
 
         --AIR AIR--
-        { CLSID = "{GAR-8}",                                 connector = rocketConnector, arg_value = 0.2 },  -- AIM-9B, aligned to -3deg armament datum
-        { CLSID = "{AIM-9P-ON-ADAPTER}",                     connector = rocketConnector, arg_value = 0.2 },  -- AIM-9P
-        { CLSID = "{AIM-9P5-ON-ADAPTER}",                    connector = rocketConnector, arg_value = 0.2 },  -- AIM-9P5
+        { CLSID = "{GAR-8}",                                  connector = rocketConnector, arg_value = 0.2 },  -- AIM-9B, aligned to -3deg armament datum
+        { CLSID = "{AIM-9P-ON-ADAPTER}",                      connector = rocketConnector, arg_value = 0.2 },  -- AIM-9P
+        { CLSID = "{AIM-9P5-ON-ADAPTER}",                     connector = rocketConnector, arg_value = 0.2 },  -- AIM-9P5
 
         --ROCKETS--
-        { CLSID = "{F3EFE0AB-E91A-42D8-9CA2-B63C91ED570A}",  connector = rocketConnector, arg_value = 0.2 }, -- LAU-10 Zuni
-        { CLSID = "{LAU-10 ZUNI_TER_2_"..side.."}",          connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-10 Zuni
-        { CLSID = "{LAU3_FFAR_WP156}",                       connector = rocketConnector, arg_value = 0.2 },
-        { CLSID = "{LAU3_FFAR_MK1HE}",                       connector = rocketConnector, arg_value = 0.2 },
-        { CLSID = "{LAU3_FFAR_MK5HEAT}",                     connector = rocketConnector, arg_value = 0.2 },
-        { CLSID = "{LAU-3 FFAR WP156_TER_2_"..side.."}",     connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-3 FFAR WP156
-        { CLSID = "{LAU-3 FFAR Mk1 HE_TER_2_"..side.."}",    connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-3 FFAR Mk1 HE
-        { CLSID = "{LAU-3 FFAR Mk5 HEAT_TER_2_"..side.."}",  connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-3 FFAR Mk5 HEAT
-        { CLSID = "{LAU68_FFAR_WP156}",                      connector = rocketConnector, arg_value = 0.2 }, -- LAU-68 FFAR WP156
-        { CLSID = "{LAU68_FFAR_MK1HE}",                      connector = rocketConnector, arg_value = 0.2 }, -- LAU-68 FFAR Mk1 HE
-        { CLSID = "{LAU68_FFAR_MK5HEAT}",                    connector = rocketConnector, arg_value = 0.2 }, -- LAU-68 FFAR Mk5 HEAT
-        { CLSID = "{LAU-68 FFAR WP156_TER_2_"..side.."}",    connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-68 FFAR WP156
-        { CLSID = "{LAU-68 FFAR Mk1 HE_TER_2_"..side.."}",   connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-68 FFAR Mk1 HE
-        { CLSID = "{LAU-68 FFAR Mk5 HEAT_TER_2_"..side.."}", connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-68 FFAR Mk5 HEAT
+        { CLSID = "{F3EFE0AB-E91A-42D8-9CA2-B63C91ED570A}",   connector = rocketConnector, arg_value = 0.2 }, -- LAU-10 Zuni
+        { CLSID = "{LAU-10 ZUNI_TER_2_"..side.."}",           connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-10 Zuni
+
+        { CLSID = "{FD90A1DC-9147-49FA-BF56-CB83EF0BD32B}",   connector = rocketConnector, arg_value = 0.2 }, -- LAU-61 Hydra M151 HE
+        { CLSID = "{3DFB7321-AB0E-11d7-9897-000476191836}",   connector = rocketConnector, arg_value = 0.2 }, -- LAU-61 Hydra M156 WP
+        { CLSID = "{LAU-61 Hydra M156 WP_TER_2_"..side.."}",  connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-3 Hydra M156 WP
+        { CLSID = "{LAU-61 Hydra M151 HE_TER_2_"..side.."}",  connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-3 Hydra M151 HE
+
+        { CLSID = "{A021F29D-18AB-4d3e-985C-FC9C60E35E9E}",   connector = rocketConnector, arg_value = 0.2 }, -- LAU 68 Hydra M151 HE
+        { CLSID = "{174C6E6D-0C3D-42ff-BCB3-0853CB371F5C}",   connector = rocketConnector, arg_value = 0.2 }, -- LAU 68 Hydra Mk5 HEAT
+        { CLSID = "{4F977A2A-CD25-44df-90EF-164BFA2AE72F}",   connector = rocketConnector, arg_value = 0.2 }, -- LAU 68 Hydra M156 WP
+        { CLSID = "{647C5F26-BDD1-41e6-A371-8DE1E4CC0E94}",   connector = rocketConnector, arg_value = 0.2 }, -- LAU 68 Hydra M257 PI
+        { CLSID = "{LAU-68 Hydra M156 WP_TER_2_"..side.."}",  connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-68 Hydra M156 WP
+        { CLSID = "{LAU-68 Hydra M151 HE_TER_2_"..side.."}",  connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-68 Hydra M151 HE
+        { CLSID = "{LAU-68 Hydra Mk5 HEAT_TER_2_"..side.."}", connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-68 Hydra Mk5 HEAT
+        { CLSID = "{LAU-68 Hydra M257 PI_TER_2_"..side.."}",  connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-68 Hydra M257 PI
+
+        { CLSID = "{LAU3_FFAR_WP156}",                        connector = rocketConnector, arg_value = 0.2 },
+        { CLSID = "{LAU3_FFAR_MK1HE}",                        connector = rocketConnector, arg_value = 0.2 },
+        { CLSID = "{LAU3_FFAR_MK5HEAT}",                      connector = rocketConnector, arg_value = 0.2 },
+        { CLSID = "{LAU-3 FFAR WP156_TER_2_"..side.."}",      connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-3 FFAR WP156
+        { CLSID = "{LAU-3 FFAR Mk1 HE_TER_2_"..side.."}",     connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-3 FFAR Mk1 HE
+        { CLSID = "{LAU-3 FFAR Mk5 HEAT_TER_2_"..side.."}",   connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-3 FFAR Mk5 HEAT
+
+        { CLSID = "{LAU68_FFAR_WP156}",                       connector = rocketConnector, arg_value = 0.2 }, -- LAU-68 FFAR WP156
+        { CLSID = "{LAU68_FFAR_MK1HE}",                       connector = rocketConnector, arg_value = 0.2 }, -- LAU-68 FFAR Mk1 HE
+        { CLSID = "{LAU68_FFAR_MK5HEAT}",                     connector = rocketConnector, arg_value = 0.2 }, -- LAU-68 FFAR Mk5 HEAT
+        { CLSID = "{LAU-68 FFAR WP156_TER_2_"..side.."}",     connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-68 FFAR WP156
+        { CLSID = "{LAU-68 FFAR Mk1 HE_TER_2_"..side.."}",    connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-68 FFAR Mk1 HE
+        { CLSID = "{LAU-68 FFAR Mk5 HEAT_TER_2_"..side.."}",  connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-68 FFAR Mk5 HEAT
 
         --MISSILES--
         { CLSID = "{AGM_45A}", connector = shrikeConnector, arg_value = 0.1 }, -- AGM-45 SHRIKE
@@ -247,29 +268,51 @@ local function get_centerline_weapons( side )
         -- { CLSID = "{D-704_BUDDY_POD}" },
 
         --ROCKETS--
-        { CLSID = "{3*LAU-61}",                              connector = rocketConnector, arg_value = 0.2 },
-        { CLSID = "{9BC82B3D-FE70-4910-B2B7-3E54EFE73262}",  connector = rocketConnector, arg_value = 0.2 },   --3*LAU 68, MK5 HE
-        { CLSID = "{F3EFE0AB-E91A-42D8-9CA2-B63C91ED570A}",  connector = rocketConnector, arg_value = 0.2 }, -- LAU-10 Zuni
-        { CLSID = "{LAU-10 ZUNI_TER_2_"..side.."}",          connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-10 Zuni
-        { CLSID = "{LAU-10 ZUNI_TER_3_"..side.."}",          connector = rocketConnector, arg_value = 0.2 }, -- Triple LAU-10 Zuni
-        { CLSID = "{LAU3_FFAR_WP156}",                       connector = rocketConnector, arg_value = 0.2 },
-        { CLSID = "{LAU3_FFAR_MK1HE}",                       connector = rocketConnector, arg_value = 0.2 },
-        { CLSID = "{LAU3_FFAR_MK5HEAT}",                     connector = rocketConnector, arg_value = 0.2 },
-        { CLSID = "{LAU-3 FFAR WP156_TER_2_"..side.."}",     connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-3 FFAR WP156
-        { CLSID = "{LAU-3 FFAR Mk1 HE_TER_2_"..side.."}",    connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-3 FFAR Mk1 HE
-        { CLSID = "{LAU-3 FFAR Mk5 HEAT_TER_2_"..side.."}",  connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-3 FFAR Mk5 HEAT
-        { CLSID = "{LAU-3 FFAR WP156_TER_3_"..side.."}",     connector = rocketConnector, arg_value = 0.2 }, -- Triple LAU-3 FFAR WP156
-        { CLSID = "{LAU-3 FFAR Mk1 HE_TER_3_"..side.."}",    connector = rocketConnector, arg_value = 0.2 }, -- Triple LAU-3 FFAR Mk1 HE
-        { CLSID = "{LAU-3 FFAR Mk5 HEAT_TER_3_"..side.."}",  connector = rocketConnector, arg_value = 0.2 }, -- Triple LAU-3 FFAR Mk5 HEAT
-        { CLSID = "{LAU68_FFAR_WP156}",                      connector = rocketConnector, arg_value = 0.2 }, -- LAU-68 FFAR WP156
-        { CLSID = "{LAU68_FFAR_MK1HE}",                      connector = rocketConnector, arg_value = 0.2 }, -- LAU-68 FFAR Mk1 HE
-        { CLSID = "{LAU68_FFAR_MK5HEAT}",                    connector = rocketConnector, arg_value = 0.2 }, -- LAU-68 FFAR Mk5 HEAT
-        { CLSID = "{LAU-68 FFAR WP156_TER_2_"..side.."}",    connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-68 FFAR WP156
-        { CLSID = "{LAU-68 FFAR Mk1 HE_TER_2_"..side.."}",   connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-68 FFAR Mk1 HE
-        { CLSID = "{LAU-68 FFAR Mk5 HEAT_TER_2_"..side.."}", connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-68 FFAR Mk5 HEAT
-        { CLSID = "{LAU-68 FFAR WP156_TER_3_"..side.."}",    connector = rocketConnector, arg_value = 0.2 }, -- Triple LAU-68 FFAR WP156
-        { CLSID = "{LAU-68 FFAR Mk1 HE_TER_3_"..side.."}",   connector = rocketConnector, arg_value = 0.2 }, -- Triple LAU-68 FFAR Mk1 HE
-        { CLSID = "{LAU-68 FFAR Mk5 HEAT_TER_3_"..side.."}", connector = rocketConnector, arg_value = 0.2 }, -- Triple LAU-68 FFAR Mk5 HEAT
+        { CLSID = "{F3EFE0AB-E91A-42D8-9CA2-B63C91ED570A}",   connector = rocketConnector, arg_value = 0.2 }, -- LAU-10 Zuni
+        { CLSID = "{LAU-10 ZUNI_TER_2_"..side.."}",           connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-10 Zuni
+        { CLSID = "{LAU-10 ZUNI_TER_3_"..side.."}",           connector = rocketConnector, arg_value = 0.2 }, -- Triple LAU-10 Zuni
+
+        { CLSID = "{FD90A1DC-9147-49FA-BF56-CB83EF0BD32B}",   connector = rocketConnector, arg_value = 0.2 }, -- LAU-61 Hydra M151 HE
+        { CLSID = "{3DFB7321-AB0E-11d7-9897-000476191836}",   connector = rocketConnector, arg_value = 0.2 }, -- LAU-61 Hydra M156 WP
+        { CLSID = "{LAU-61 Hydra M156 WP_TER_2_"..side.."}",  connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-61 Hydra M156 WP
+        { CLSID = "{LAU-61 Hydra M151 HE_TER_2_"..side.."}",  connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-61 Hydra M151 HE
+        { CLSID = "{LAU-61 Hydra M156 WP_TER_3_"..side.."}",  connector = rocketConnector, arg_value = 0.2 }, -- Triple LAU-61 Hydra M156 WP
+        { CLSID = "{LAU-61 Hydra M151 HE_TER_3_"..side.."}",  connector = rocketConnector, arg_value = 0.2 }, -- Triple LAU-61 Hydra M151 HE
+
+        -- { CLSID = "{3*LAU-61}",                               connector = rocketConnector, arg_value = 0.2 }, -- Triple LAU-61 Hydra M151 HE??
+        -- { CLSID = "{A76344EB-32D2-4532-8FA2-0C1BDC00747E}",   connector = rocketConnector, arg_value = 0.2 }, -- Triple LAU-61 Hydra M151 HE??
+
+        { CLSID = "{A021F29D-18AB-4d3e-985C-FC9C60E35E9E}",   connector = rocketConnector, arg_value = 0.2 }, -- LAU 68 Hydra M151 HE
+        { CLSID = "{174C6E6D-0C3D-42ff-BCB3-0853CB371F5C}",   connector = rocketConnector, arg_value = 0.2 }, -- LAU 68 Hydra Mk5 HEAT
+        { CLSID = "{4F977A2A-CD25-44df-90EF-164BFA2AE72F}",   connector = rocketConnector, arg_value = 0.2 }, -- LAU 68 Hydra M156 WP
+        { CLSID = "{LAU-68 Hydra M156 WP_TER_2_"..side.."}",  connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-68 Hydra M156 WP
+        { CLSID = "{LAU-68 Hydra M151 HE_TER_2_"..side.."}",  connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-68 Hydra M151 HE
+        { CLSID = "{LAU-68 Hydra Mk5 HEAT_TER_2_"..side.."}", connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-68 Hydra Mk5 HEAT
+        { CLSID = "{LAU-68 Hydra M257 PI_TER_2_"..side.."}",  connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-68 Hydra M257 PI
+        { CLSID = "{C2593383-3CA8-4b18-B73D-0E750BCA1C85}",   connector = rocketConnector, arg_value = 0.2 }, -- Triple LAU 68 Hydra M156 Wht Phos
+        { CLSID = "{64329ED9-B14C-4c0b-A923-A3C911DA1527}",   connector = rocketConnector, arg_value = 0.2 }, -- Triple LAU 68 Hydra M151 HE
+        { CLSID = "{9BC82B3D-FE70-4910-B2B7-3E54EFE73262}",   connector = rocketConnector, arg_value = 0.2 }, -- Triple LAU 68 Hydra MK5 HEAT
+        { CLSID = "{E6966004-A525-4f47-AF94-BCFEDF8FDBDA}",   connector = rocketConnector, arg_value = 0.2 }, -- Triple LAU 68 Hydra M257 PI
+
+        { CLSID = "{LAU3_FFAR_WP156}",                        connector = rocketConnector, arg_value = 0.2 },
+        { CLSID = "{LAU3_FFAR_MK1HE}",                        connector = rocketConnector, arg_value = 0.2 },
+        { CLSID = "{LAU3_FFAR_MK5HEAT}",                      connector = rocketConnector, arg_value = 0.2 },
+        { CLSID = "{LAU-3 FFAR WP156_TER_2_"..side.."}",      connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-3 FFAR WP156
+        { CLSID = "{LAU-3 FFAR Mk1 HE_TER_2_"..side.."}",     connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-3 FFAR Mk1 HE
+        { CLSID = "{LAU-3 FFAR Mk5 HEAT_TER_2_"..side.."}",   connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-3 FFAR Mk5 HEAT
+        { CLSID = "{LAU-3 FFAR WP156_TER_3_"..side.."}",      connector = rocketConnector, arg_value = 0.2 }, -- Triple LAU-3 FFAR WP156
+        { CLSID = "{LAU-3 FFAR Mk1 HE_TER_3_"..side.."}",     connector = rocketConnector, arg_value = 0.2 }, -- Triple LAU-3 FFAR Mk1 HE
+        { CLSID = "{LAU-3 FFAR Mk5 HEAT_TER_3_"..side.."}",   connector = rocketConnector, arg_value = 0.2 }, -- Triple LAU-3 FFAR Mk5 HEAT
+
+        { CLSID = "{LAU68_FFAR_WP156}",                       connector = rocketConnector, arg_value = 0.2 }, -- LAU-68 FFAR WP156
+        { CLSID = "{LAU68_FFAR_MK1HE}",                       connector = rocketConnector, arg_value = 0.2 }, -- LAU-68 FFAR Mk1 HE
+        { CLSID = "{LAU68_FFAR_MK5HEAT}",                     connector = rocketConnector, arg_value = 0.2 }, -- LAU-68 FFAR Mk5 HEAT
+        { CLSID = "{LAU-68 FFAR WP156_TER_2_"..side.."}",     connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-68 FFAR WP156
+        { CLSID = "{LAU-68 FFAR Mk1 HE_TER_2_"..side.."}",    connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-68 FFAR Mk1 HE
+        { CLSID = "{LAU-68 FFAR Mk5 HEAT_TER_2_"..side.."}",  connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-68 FFAR Mk5 HEAT
+        { CLSID = "{LAU-68 FFAR WP156_TER_3_"..side.."}",     connector = rocketConnector, arg_value = 0.2 }, -- Triple LAU-68 FFAR WP156
+        { CLSID = "{LAU-68 FFAR Mk1 HE_TER_3_"..side.."}",    connector = rocketConnector, arg_value = 0.2 }, -- Triple LAU-68 FFAR Mk1 HE
+        { CLSID = "{LAU-68 FFAR Mk5 HEAT_TER_3_"..side.."}",  connector = rocketConnector, arg_value = 0.2 }, -- Triple LAU-68 FFAR Mk5 HEAT
 
         --BOMBS--
         { CLSID = "{ADD3FAE1-EBF6-4EF9-8EFC-B36B5DDF1E6B}" },   -- Mk-20 Rockeye cluster bomb

--- a/A-4E-C/A-4E-C.lua
+++ b/A-4E-C/A-4E-C.lua
@@ -75,15 +75,16 @@ local function get_outboard_weapons( side )
     local tbl = {
 	
 		--AIR AIR--
-        { CLSID = "{GAR-8}",                                 connector = rocketConnector, arg_value = 0.2 },  -- AIM-9B, aligned to -3deg armament datum
-        { CLSID = "{AIM-9P-ON-ADAPTER}",                     connector = rocketConnector, arg_value = 0.2 },  -- AIM-9P
-        { CLSID = "{AIM-9P5-ON-ADAPTER}",                    connector = rocketConnector, arg_value = 0.2 },  -- AIM-9P5
+        { CLSID = "{GAR-8}",                                connector = rocketConnector, arg_value = 0.2 },  -- AIM-9B, aligned to -3deg armament datum
+        { CLSID = "{AIM-9P-ON-ADAPTER}",                    connector = rocketConnector, arg_value = 0.2 },  -- AIM-9P
+        { CLSID = "{AIM-9P5-ON-ADAPTER}",                   connector = rocketConnector, arg_value = 0.2 },  -- AIM-9P5
 	
         --ROCKETS--
         { CLSID = "{F3EFE0AB-E91A-42D8-9CA2-B63C91ED570A}", connector = rocketConnector, arg_value = 0.2 }, -- LAU-10 Zuni
 
-        { CLSID = "{FD90A1DC-9147-49FA-BF56-CB83EF0BD32B}", connector = rocketConnector, arg_value = 0.2 }, -- LAU-61 Hydra M151 HE
-        { CLSID = "{3DFB7321-AB0E-11d7-9897-000476191836}", connector = rocketConnector, arg_value = 0.2 }, -- LAU-61 Hydra M156 WP
+        { CLSID = "{LAU3_HE151}",                           connector = rocketConnector, arg_value = 0.2 }, -- LAU-3 Hydra M151 HE
+        { CLSID = "{LAU3_HE5}",                             connector = rocketConnector, arg_value = 0.2 }, -- LAU-3 Hydra Mk5 HEAT
+        { CLSID = "{LAU3_WP156}",                           connector = rocketConnector, arg_value = 0.2 }, -- LAU-3 Hydra M156 WP
 
         { CLSID = "{A021F29D-18AB-4d3e-985C-FC9C60E35E9E}", connector = rocketConnector, arg_value = 0.2 }, -- LAU 68 Hydra M151 HE
         { CLSID = "{174C6E6D-0C3D-42ff-BCB3-0853CB371F5C}", connector = rocketConnector, arg_value = 0.2 }, -- LAU 68 Hydra Mk5 HEAT
@@ -162,10 +163,12 @@ local function get_inboard_weapons( side )
         { CLSID = "{F3EFE0AB-E91A-42D8-9CA2-B63C91ED570A}",   connector = rocketConnector, arg_value = 0.2 }, -- LAU-10 Zuni
         { CLSID = "{LAU-10 ZUNI_TER_2_"..side.."}",           connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-10 Zuni
 
-        { CLSID = "{FD90A1DC-9147-49FA-BF56-CB83EF0BD32B}",   connector = rocketConnector, arg_value = 0.2 }, -- LAU-61 Hydra M151 HE
-        { CLSID = "{3DFB7321-AB0E-11d7-9897-000476191836}",   connector = rocketConnector, arg_value = 0.2 }, -- LAU-61 Hydra M156 WP
-        { CLSID = "{LAU-61 Hydra M156 WP_TER_2_"..side.."}",  connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-3 Hydra M156 WP
-        { CLSID = "{LAU-61 Hydra M151 HE_TER_2_"..side.."}",  connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-3 Hydra M151 HE
+        { CLSID = "{LAU3_HE151}",                             connector = rocketConnector, arg_value = 0.2 }, -- LAU-3 Hydra M151 HE
+        { CLSID = "{LAU3_HE5}",                               connector = rocketConnector, arg_value = 0.2 }, -- LAU-3 Hydra Mk5 HEAT
+        { CLSID = "{LAU3_WP156}",                             connector = rocketConnector, arg_value = 0.2 }, -- LAU-3 Hydra M156 WP
+        { CLSID = "{LAU-3 Hydra M151 HE_TER_2_"..side.."}",   connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-3 Hydra M151 HE
+        { CLSID = "{LAU-3 Hydra Mk5 HEAT_TER_2_"..side.."}",  connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-3 Hydra Mk5 HEAT
+        { CLSID = "{LAU-3 Hydra M156 WP_TER_2_"..side.."}",   connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-3 Hydra M156 WP
 
         { CLSID = "{A021F29D-18AB-4d3e-985C-FC9C60E35E9E}",   connector = rocketConnector, arg_value = 0.2 }, -- LAU 68 Hydra M151 HE
         { CLSID = "{174C6E6D-0C3D-42ff-BCB3-0853CB371F5C}",   connector = rocketConnector, arg_value = 0.2 }, -- LAU 68 Hydra Mk5 HEAT
@@ -272,12 +275,15 @@ local function get_centerline_weapons( side )
         { CLSID = "{LAU-10 ZUNI_TER_2_"..side.."}",           connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-10 Zuni
         { CLSID = "{LAU-10 ZUNI_TER_3_"..side.."}",           connector = rocketConnector, arg_value = 0.2 }, -- Triple LAU-10 Zuni
 
-        { CLSID = "{FD90A1DC-9147-49FA-BF56-CB83EF0BD32B}",   connector = rocketConnector, arg_value = 0.2 }, -- LAU-61 Hydra M151 HE
-        { CLSID = "{3DFB7321-AB0E-11d7-9897-000476191836}",   connector = rocketConnector, arg_value = 0.2 }, -- LAU-61 Hydra M156 WP
-        { CLSID = "{LAU-61 Hydra M156 WP_TER_2_"..side.."}",  connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-61 Hydra M156 WP
-        { CLSID = "{LAU-61 Hydra M151 HE_TER_2_"..side.."}",  connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-61 Hydra M151 HE
-        { CLSID = "{LAU-61 Hydra M156 WP_TER_3_"..side.."}",  connector = rocketConnector, arg_value = 0.2 }, -- Triple LAU-61 Hydra M156 WP
-        { CLSID = "{LAU-61 Hydra M151 HE_TER_3_"..side.."}",  connector = rocketConnector, arg_value = 0.2 }, -- Triple LAU-61 Hydra M151 HE
+        { CLSID = "{LAU3_HE151}",                             connector = rocketConnector, arg_value = 0.2 }, -- LAU-3 Hydra M151 HE
+        { CLSID = "{LAU3_HE5}",                               connector = rocketConnector, arg_value = 0.2 }, -- LAU-3 Hydra Mk5 HEAT
+        { CLSID = "{LAU3_WP156}",                             connector = rocketConnector, arg_value = 0.2 }, -- LAU-3 Hydra M156 WP
+        { CLSID = "{LAU-3 Hydra M151 HE_TER_2_"..side.."}",   connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-3 Hydra M151 HE
+        { CLSID = "{LAU-3 Hydra Mk5 HEAT_TER_2_"..side.."}",  connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-3 Hydra Mk5 HEAT
+        { CLSID = "{LAU-3 Hydra M156 WP_TER_2_"..side.."}",   connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-3 Hydra M156 WP
+        { CLSID = "{LAU-3 Hydra M151 HE_TER_3_"..side.."}",   connector = rocketConnector, arg_value = 0.2 }, -- Triple LAU-3 Hydra M151 HE
+        { CLSID = "{LAU-3 Hydra Mk5 HEAT_TER_3_"..side.."}",  connector = rocketConnector, arg_value = 0.2 }, -- Triple LAU-3 Hydra Mk5 HEAT
+        { CLSID = "{LAU-3 Hydra M156 WP_TER_3_"..side.."}",   connector = rocketConnector, arg_value = 0.2 }, -- Triple LAU-3 Hydra M156 WP
 
         -- { CLSID = "{3*LAU-61}",                               connector = rocketConnector, arg_value = 0.2 }, -- Triple LAU-61 Hydra M151 HE??
         -- { CLSID = "{A76344EB-32D2-4532-8FA2-0C1BDC00747E}",   connector = rocketConnector, arg_value = 0.2 }, -- Triple LAU-61 Hydra M151 HE??

--- a/A-4E-C/A-4E-C.lua
+++ b/A-4E-C/A-4E-C.lua
@@ -82,9 +82,8 @@ local function get_outboard_weapons( side )
         --ROCKETS--
         { CLSID = "{F3EFE0AB-E91A-42D8-9CA2-B63C91ED570A}", connector = rocketConnector, arg_value = 0.2 }, -- LAU-10 Zuni
 
-        { CLSID = "{LAU3_HE151}",                           connector = rocketConnector, arg_value = 0.2 }, -- LAU-3 Hydra M151 HE
-        { CLSID = "{LAU3_HE5}",                             connector = rocketConnector, arg_value = 0.2 }, -- LAU-3 Hydra Mk5 HEAT
-        { CLSID = "{LAU3_WP156}",                           connector = rocketConnector, arg_value = 0.2 }, -- LAU-3 Hydra M156 WP
+        { CLSID = "{FD90A1DC-9147-49FA-BF56-CB83EF0BD32B}", connector = rocketConnector, arg_value = 0.2 }, -- LAU-61 Hydra M151 HE
+        { CLSID = "{3DFB7321-AB0E-11d7-9897-000476191836}", connector = rocketConnector, arg_value = 0.2 }, -- LAU-61 Hydra M156 WP
 
         { CLSID = "{A021F29D-18AB-4d3e-985C-FC9C60E35E9E}", connector = rocketConnector, arg_value = 0.2 }, -- LAU 68 Hydra M151 HE
         { CLSID = "{174C6E6D-0C3D-42ff-BCB3-0853CB371F5C}", connector = rocketConnector, arg_value = 0.2 }, -- LAU 68 Hydra Mk5 HEAT
@@ -163,12 +162,10 @@ local function get_inboard_weapons( side )
         { CLSID = "{F3EFE0AB-E91A-42D8-9CA2-B63C91ED570A}",   connector = rocketConnector, arg_value = 0.2 }, -- LAU-10 Zuni
         { CLSID = "{LAU-10 ZUNI_TER_2_"..side.."}",           connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-10 Zuni
 
-        { CLSID = "{LAU3_HE151}",                             connector = rocketConnector, arg_value = 0.2 }, -- LAU-3 Hydra M151 HE
-        { CLSID = "{LAU3_HE5}",                               connector = rocketConnector, arg_value = 0.2 }, -- LAU-3 Hydra Mk5 HEAT
-        { CLSID = "{LAU3_WP156}",                             connector = rocketConnector, arg_value = 0.2 }, -- LAU-3 Hydra M156 WP
-        { CLSID = "{LAU-3 Hydra M151 HE_TER_2_"..side.."}",   connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-3 Hydra M151 HE
-        { CLSID = "{LAU-3 Hydra Mk5 HEAT_TER_2_"..side.."}",  connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-3 Hydra Mk5 HEAT
-        { CLSID = "{LAU-3 Hydra M156 WP_TER_2_"..side.."}",   connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-3 Hydra M156 WP
+        { CLSID = "{FD90A1DC-9147-49FA-BF56-CB83EF0BD32B}",   connector = rocketConnector, arg_value = 0.2 }, -- LAU-61 Hydra M151 HE
+        { CLSID = "{3DFB7321-AB0E-11d7-9897-000476191836}",   connector = rocketConnector, arg_value = 0.2 }, -- LAU-61 Hydra M156 WP
+        { CLSID = "{LAU-61 Hydra M156 WP_TER_2_"..side.."}",  connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-61 Hydra M156 WP
+        { CLSID = "{LAU-61 Hydra M151 HE_TER_2_"..side.."}",  connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-61 Hydra M151 HE
 
         { CLSID = "{A021F29D-18AB-4d3e-985C-FC9C60E35E9E}",   connector = rocketConnector, arg_value = 0.2 }, -- LAU 68 Hydra M151 HE
         { CLSID = "{174C6E6D-0C3D-42ff-BCB3-0853CB371F5C}",   connector = rocketConnector, arg_value = 0.2 }, -- LAU 68 Hydra Mk5 HEAT
@@ -275,15 +272,12 @@ local function get_centerline_weapons( side )
         { CLSID = "{LAU-10 ZUNI_TER_2_"..side.."}",           connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-10 Zuni
         { CLSID = "{LAU-10 ZUNI_TER_3_"..side.."}",           connector = rocketConnector, arg_value = 0.2 }, -- Triple LAU-10 Zuni
 
-        { CLSID = "{LAU3_HE151}",                             connector = rocketConnector, arg_value = 0.2 }, -- LAU-3 Hydra M151 HE
-        { CLSID = "{LAU3_HE5}",                               connector = rocketConnector, arg_value = 0.2 }, -- LAU-3 Hydra Mk5 HEAT
-        { CLSID = "{LAU3_WP156}",                             connector = rocketConnector, arg_value = 0.2 }, -- LAU-3 Hydra M156 WP
-        { CLSID = "{LAU-3 Hydra M151 HE_TER_2_"..side.."}",   connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-3 Hydra M151 HE
-        { CLSID = "{LAU-3 Hydra Mk5 HEAT_TER_2_"..side.."}",  connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-3 Hydra Mk5 HEAT
-        { CLSID = "{LAU-3 Hydra M156 WP_TER_2_"..side.."}",   connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-3 Hydra M156 WP
-        { CLSID = "{LAU-3 Hydra M151 HE_TER_3_"..side.."}",   connector = rocketConnector, arg_value = 0.2 }, -- Triple LAU-3 Hydra M151 HE
-        { CLSID = "{LAU-3 Hydra Mk5 HEAT_TER_3_"..side.."}",  connector = rocketConnector, arg_value = 0.2 }, -- Triple LAU-3 Hydra Mk5 HEAT
-        { CLSID = "{LAU-3 Hydra M156 WP_TER_3_"..side.."}",   connector = rocketConnector, arg_value = 0.2 }, -- Triple LAU-3 Hydra M156 WP
+        { CLSID = "{FD90A1DC-9147-49FA-BF56-CB83EF0BD32B}",   connector = rocketConnector, arg_value = 0.2 }, -- LAU-61 Hydra M151 HE
+        { CLSID = "{3DFB7321-AB0E-11d7-9897-000476191836}",   connector = rocketConnector, arg_value = 0.2 }, -- LAU-61 Hydra M156 WP
+        { CLSID = "{LAU-61 Hydra M156 WP_TER_2_"..side.."}",  connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-61 Hydra M156 WP
+        { CLSID = "{LAU-61 Hydra M151 HE_TER_2_"..side.."}",  connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-61 Hydra M151 HE
+        { CLSID = "{LAU-61 Hydra M156 WP_TER_3_"..side.."}",  connector = rocketConnector, arg_value = 0.2 }, -- Triple LAU-61 Hydra M156 WP
+        { CLSID = "{LAU-61 Hydra M151 HE_TER_3_"..side.."}",  connector = rocketConnector, arg_value = 0.2 }, -- Triple LAU-61 Hydra M151 HE
 
         -- { CLSID = "{3*LAU-61}",                               connector = rocketConnector, arg_value = 0.2 }, -- Triple LAU-61 Hydra M151 HE??
         -- { CLSID = "{A76344EB-32D2-4532-8FA2-0C1BDC00747E}",   connector = rocketConnector, arg_value = 0.2 }, -- Triple LAU-61 Hydra M151 HE??
@@ -296,14 +290,14 @@ local function get_centerline_weapons( side )
         { CLSID = "{LAU-68 Hydra M151 HE_TER_2_"..side.."}",  connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-68 Hydra M151 HE
         { CLSID = "{LAU-68 Hydra Mk5 HEAT_TER_2_"..side.."}", connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-68 Hydra Mk5 HEAT
         { CLSID = "{LAU-68 Hydra M257 PI_TER_2_"..side.."}",  connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-68 Hydra M257 PI
-        { CLSID = "{C2593383-3CA8-4b18-B73D-0E750BCA1C85}",   connector = rocketConnector, arg_value = 0.2 }, -- Triple LAU 68 Hydra M156 Wht Phos
-        { CLSID = "{64329ED9-B14C-4c0b-A923-A3C911DA1527}",   connector = rocketConnector, arg_value = 0.2 }, -- Triple LAU 68 Hydra M151 HE
-        { CLSID = "{9BC82B3D-FE70-4910-B2B7-3E54EFE73262}",   connector = rocketConnector, arg_value = 0.2 }, -- Triple LAU 68 Hydra MK5 HEAT
-        { CLSID = "{E6966004-A525-4f47-AF94-BCFEDF8FDBDA}",   connector = rocketConnector, arg_value = 0.2 }, -- Triple LAU 68 Hydra M257 PI
+        { CLSID = "{LAU-68 Hydra M156 WP_TER_3_"..side.."}",  connector = rocketConnector, arg_value = 0.2 }, -- Triple LAU 68 Hydra M156 Wht Phos
+        { CLSID = "{LAU-68 Hydra M151 HE_TER_3_"..side.."}",  connector = rocketConnector, arg_value = 0.2 }, -- Triple LAU 68 Hydra M151 HE
+        { CLSID = "{LAU-68 Hydra Mk5 HEAT_TER_3_"..side.."}", connector = rocketConnector, arg_value = 0.2 }, -- Triple LAU 68 Hydra MK5 HEAT
+        { CLSID = "{LAU-68 Hydra M257 PI_TER_3_"..side.."}",  connector = rocketConnector, arg_value = 0.2 }, -- Triple LAU 68 Hydra M257 PI
 
-        { CLSID = "{LAU3_FFAR_WP156}",                        connector = rocketConnector, arg_value = 0.2 },
-        { CLSID = "{LAU3_FFAR_MK1HE}",                        connector = rocketConnector, arg_value = 0.2 },
-        { CLSID = "{LAU3_FFAR_MK5HEAT}",                      connector = rocketConnector, arg_value = 0.2 },
+        { CLSID = "{LAU3_FFAR_WP156}",                        connector = rocketConnector, arg_value = 0.2 }, -- LAU-3 FFAR WP156
+        { CLSID = "{LAU3_FFAR_MK1HE}",                        connector = rocketConnector, arg_value = 0.2 }, -- LAU-3 FFAR Mk1 HE
+        { CLSID = "{LAU3_FFAR_MK5HEAT}",                      connector = rocketConnector, arg_value = 0.2 }, -- LAU-3 FFAR Mk5 HEAT
         { CLSID = "{LAU-3 FFAR WP156_TER_2_"..side.."}",      connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-3 FFAR WP156
         { CLSID = "{LAU-3 FFAR Mk1 HE_TER_2_"..side.."}",     connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-3 FFAR Mk1 HE
         { CLSID = "{LAU-3 FFAR Mk5 HEAT_TER_2_"..side.."}",   connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-3 FFAR Mk5 HEAT

--- a/A-4E-C/A-4E-C.lua
+++ b/A-4E-C/A-4E-C.lua
@@ -285,6 +285,7 @@ local function get_centerline_weapons( side )
         { CLSID = "{A021F29D-18AB-4d3e-985C-FC9C60E35E9E}",   connector = rocketConnector, arg_value = 0.2 }, -- LAU 68 Hydra M151 HE
         { CLSID = "{174C6E6D-0C3D-42ff-BCB3-0853CB371F5C}",   connector = rocketConnector, arg_value = 0.2 }, -- LAU 68 Hydra Mk5 HEAT
         { CLSID = "{4F977A2A-CD25-44df-90EF-164BFA2AE72F}",   connector = rocketConnector, arg_value = 0.2 }, -- LAU 68 Hydra M156 WP
+        { CLSID = "{647C5F26-BDD1-41e6-A371-8DE1E4CC0E94}",   connector = rocketConnector, arg_value = 0.2 }, -- LAU 68 Hydra M257 PI
         { CLSID = "{LAU-68 Hydra M156 WP_TER_2_"..side.."}",  connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-68 Hydra M156 WP
         { CLSID = "{LAU-68 Hydra M151 HE_TER_2_"..side.."}",  connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-68 Hydra M151 HE
         { CLSID = "{LAU-68 Hydra Mk5 HEAT_TER_2_"..side.."}", connector = rocketConnector, arg_value = 0.2 }, -- Dual LAU-68 Hydra Mk5 HEAT

--- a/A-4E-C/Cockpit/Scripts/Systems/stores_config.lua
+++ b/A-4E-C/Cockpit/Scripts/Systems/stores_config.lua
@@ -83,6 +83,42 @@ loadout_names = {
     ["{LAU-68 FFAR Mk5 HEAT_TER_2_R}"]          = "ROCKETS - LAU-68 * 2 - FFAR MK5 HEAT - TER",
     ["{LAU-68 FFAR Mk5 HEAT_TER_3_C}"]          = "ROCKETS - LAU-68 * 3 - FFAR MK5 HEAT - TER",
 
+    ["{FD90A1DC-9147-49FA-BF56-CB83EF0BD32B}"]  = "ROCKETS - LAU-61 - Hydra M151 HE",
+    ["{LAU-61 Hydra M151_TER_3_C}"]             = "ROCKETS - LAU-61 * 2 - Hydra M151 HE - TER",
+    ["{LAU-61 Hydra M151_TER_2_C}"]             = "ROCKETS - LAU-61 * 2 - Hydra M151 HE - TER",
+    ["{LAU-61 Hydra M151_TER_2_L}"]             = "ROCKETS - LAU-61 * 2 - Hydra M151 HE - TER",
+    ["{LAU-61 Hydra M151_TER_2_R}"]             = "ROCKETS - LAU-61 * 3 - Hydra M151 HE - TER",
+
+    ["{3DFB7321-AB0E-11d7-9897-000476191836}"]  = "ROCKETS - LAU-61 - Hydra M156 WP",
+    ["{LAU-61 Hydra M156 WP_TER_2_C}"]          = "ROCKETS - LAU-61 * 2 - Hydra M156 WP - TER",
+    ["{LAU-61 Hydra M156 WP_TER_2_L}"]          = "ROCKETS - LAU-61 * 2 - Hydra M156 WP - TER",
+    ["{LAU-61 Hydra M156 WP_TER_2_R}"]          = "ROCKETS - LAU-61 * 2 - Hydra M156 WP - TER",
+    ["{LAU-61 Hydra M156 WP_TER_3_C}"]          = "ROCKETS - LAU-61 * 3 - Hydra M156 WP - TER",
+
+    ["{A021F29D-18AB-4d3e-985C-FC9C60E35E9E}"]  = "ROCKETS - LAU-68 - Hydra M151 HE",
+    ["{LAU-68 Hydra M151 HE_TER_3_C}"]          = "ROCKETS - LAU-68 * 2 - Hydra M151 HE - TER",
+    ["{LAU-68 Hydra M151 HE_TER_2_C}"]          = "ROCKETS - LAU-68 * 2 - Hydra M151 HE - TER",
+    ["{LAU-68 Hydra M151 HE_TER_2_L}"]          = "ROCKETS - LAU-68 * 2 - Hydra M151 HE - TER",
+    ["{LAU-68 Hydra M151 HE_TER_2_R}"]          = "ROCKETS - LAU-68 * 3 - Hydra M151 HE - TER",
+
+    ["{174C6E6D-0C3D-42ff-BCB3-0853CB371F5C}"]  = "ROCKETS - LAU-68 - Hydra Mk5 HEAT - TER",
+    ["{LAU-68 Hydra Mk5 HEAT_TER_3_C}"]         = "ROCKETS - LAU-68 * 2 - Hydra Mk5 HEAT - TER",
+    ["{LAU-68 Hydra Mk5 HEAT_TER_2_C}"]         = "ROCKETS - LAU-68 * 2 - Hydra Mk5 HEAT - TER",
+    ["{LAU-68 Hydra Mk5 HEAT_TER_2_L}"]         = "ROCKETS - LAU-68 * 2 - Hydra Mk5 HEAT - TER",
+    ["{LAU-68 Hydra Mk5 HEAT_TER_2_R}"]         = "ROCKETS - LAU-68 * 3 - Hydra Mk5 HEAT - TER",
+
+    ["{4F977A2A-CD25-44df-90EF-164BFA2AE72F}"]  = "ROCKETS - LAU-68 - Hydra M156 WP - TER",
+    ["{LAU-68 Hydra M156 WP_TER_3_C}"]          = "ROCKETS - LAU-68 * 2 - Hydra M156 WP - TER",
+    ["{LAU-68 Hydra M156 WP_TER_2_C}"]          = "ROCKETS - LAU-68 * 2 - Hydra M156 WP - TER",
+    ["{LAU-68 Hydra M156 WP_TER_2_L}"]          = "ROCKETS - LAU-68 * 2 - Hydra M156 WP - TER",
+    ["{LAU-68 Hydra M156 WP_TER_2_R}"]          = "ROCKETS - LAU-68 * 3 - Hydra M156 WP - TER",
+
+    ["{647C5F26-BDD1-41e6-A371-8DE1E4CC0E94}"]  = "ROCKETS - LAU-68 - Hydra M257 PI - TER",
+    ["{LAU-68 Hydra M257 PI_TER_3_C}"]          = "ROCKETS - LAU-68 * 2 - Hydra M257 PI - TER",
+    ["{LAU-68 Hydra M257 PI_TER_2_C}"]          = "ROCKETS - LAU-68 * 2 - Hydra M257 PI - TER",
+    ["{LAU-68 Hydra M257 PI_TER_2_L}"]          = "ROCKETS - LAU-68 * 2 - Hydra M257 PI - TER",
+    ["{LAU-68 Hydra M257 PI_TER_2_R}"]          = "ROCKETS - LAU-68 * 3 - Hydra M257 PI - TER",
+
     --MISSILES--
     ["{AGM_45A}"]                               = "MISSILE - AGM-45A SHRIKE ARM",
 

--- a/A-4E-C/Weapons/A4E_Weapons.lua
+++ b/A-4E-C/Weapons/A4E_Weapons.lua
@@ -1749,8 +1749,9 @@ local rack_data = {
 }
 
 local rocket_data = {
-    ["LAU-61 Hydra M151 HE"]   = { name = "Hydra M151 HE",  mass = 100 + 19 * (23.6 * POUNDS_TO_KG),  wstype = {4,7,33,147}, payload_CLSID = "{FD90A1DC-9147-49FA-BF56-CB83EF0BD32B}", shapename = "LAU-61", pic = 'LAU61.png', count = 19, cx = 0.00146484375},
-    ["LAU-61 Hydra M156 WP"]   = { name = "Hydra M156 WP",  mass = 100 + 19 * (23.3 * POUNDS_TO_KG),  wstype = {4,7,33,147}, payload_CLSID = "{3DFB7321-AB0E-11d7-9897-000476191836}", shapename = "LAU-61", pic = 'LAU61.png', count = 19, cx = 0.00146484375},
+    ["LAU-3 Hydra M151 HE"]   = { name = "Hydra M151 HE",  mass = 100 + 19 * (23.6 * POUNDS_TO_KG),  wstype = {4,7,33,147}, payload_CLSID = "{LAU3_HE151}",                            shapename = "LAU-3",  pic = 'LAU61.png', count = 19, cx = 0.00146484375},
+    ["LAU-3 Hydra Mk5 HEAT"]   = { name = "Hydra M151 HE",  mass = 100 + 19 * (23.7 * POUNDS_TO_KG), wstype = {4,7,33,147}, payload_CLSID = "{LAU3_HE5}",                              shapename = "LAU-3",  pic = 'LAU61.png', count = 19, cx = 0.00146484375},
+    ["LAU-3 Hydra M156 WP"]   = { name = "Hydra M156 WP",  mass = 100 + 19 * (23.3 * POUNDS_TO_KG),  wstype = {4,7,33,147}, payload_CLSID = "{LAU3_WP156}",                            shapename = "LAU-3",  pic = 'LAU61.png', count = 19, cx = 0.00146484375},
 
     ["LAU-68 Hydra M151 HE"]   = { name = "Hydra M151 HE",  mass = 41.73 + 7 * (23.6 * POUNDS_TO_KG), wstype = {4,7,33,147}, payload_CLSID = "{A021F29D-18AB-4d3e-985C-FC9C60E35E9E}", shapename = "LAU-68", pic = 'LAU68.png', count = 7,  cx = 0.00146484375},
     ["LAU-68 Hydra Mk5 HEAT"]  = { name = "Hydra Mk5 HEAT", mass = 41.73 + 7 * (23.7 * POUNDS_TO_KG), wstype = {4,7,33,147}, payload_CLSID = "{174C6E6D-0C3D-42ff-BCB3-0853CB371F5C}", shapename = "LAU-68", pic = 'LAU68.png', count = 7,  cx = 0.00146484375},
@@ -2065,15 +2066,20 @@ declare_loadout(bru_42_lau("LAU-3 FFAR Mk5 HEAT", 2, 0))    -- {LAU-3 FFAR Mk5 H
 declare_loadout(bru_42_lau("LAU-3 FFAR Mk5 HEAT", 2, -1))   -- {LAU-3 FFAR Mk5 HEAT_TER_2_L}
 declare_loadout(bru_42_lau("LAU-3 FFAR Mk5 HEAT", 2, 1))    -- {LAU-3 FFAR Mk5 HEAT_TER_2_R}
 
-declare_loadout(bru_42_lau("LAU-61 Hydra M151 HE", 3, 0))   -- {LAU-61 Hydra M151_TER_3_C}
-declare_loadout(bru_42_lau("LAU-61 Hydra M151 HE", 2, 0))   -- {LAU-61 Hydra M151_TER_2_C}
-declare_loadout(bru_42_lau("LAU-61 Hydra M151 HE", 2, -1))  -- {LAU-61 Hydra M151_TER_2_L}
-declare_loadout(bru_42_lau("LAU-61 Hydra M151 HE", 2, 1))   -- {LAU-61 Hydra M151_TER_2_R}
+declare_loadout(bru_42_lau("LAU-3 Hydra M151 HE", 3, 0))    -- {LAU-3 Hydra M151 HE_TER_3_C}
+declare_loadout(bru_42_lau("LAU-3 Hydra M151 HE", 2, 0))    -- {LAU-3 Hydra M151 HE_TER_2_C}
+declare_loadout(bru_42_lau("LAU-3 Hydra M151 HE", 2, -1))   -- {LAU-3 Hydra M151 HE_TER_2_L}
+declare_loadout(bru_42_lau("LAU-3 Hydra M151 HE", 2, 1))    -- {LAU-3 Hydra M151 HE_TER_2_R}
 
-declare_loadout(bru_42_lau("LAU-61 Hydra M156 WP", 3, 0))   -- {LAU-61 Hydra M156 WP_TER_3_C}
-declare_loadout(bru_42_lau("LAU-61 Hydra M156 WP", 2, 0))   -- {LAU-61 Hydra M156 WP_TER_2_C}
-declare_loadout(bru_42_lau("LAU-61 Hydra M156 WP", 2, -1))  -- {LAU-61 Hydra M156 WP_TER_2_L}
-declare_loadout(bru_42_lau("LAU-61 Hydra M156 WP", 2, 1))   -- {LAU-61 Hydra M156 WP_TER_2_R}
+declare_loadout(bru_42_lau("LAU-3 Hydra Mk5 HEAT", 3, 0))   -- {LAU-3 Hydra Mk5 HEAT_TER_3_C}
+declare_loadout(bru_42_lau("LAU-3 Hydra Mk5 HEAT", 2, 0))   -- {LAU-3 Hydra Mk5 HEAT_TER_2_C}
+declare_loadout(bru_42_lau("LAU-3 Hydra Mk5 HEAT", 2, -1))  -- {LAU-3 Hydra Mk5 HEAT_TER_2_L}
+declare_loadout(bru_42_lau("LAU-3 Hydra Mk5 HEAT", 2, 1))   -- {LAU-3 Hydra Mk5 HEAT_TER_2_R}
+
+declare_loadout(bru_42_lau("LAU-3 Hydra M156 WP", 3, 0))    -- {LAU-3 Hydra M156 WP_TER_3_C}
+declare_loadout(bru_42_lau("LAU-3 Hydra M156 WP", 2, 0))    -- {LAU-3 Hydra M156 WP_TER_2_C}
+declare_loadout(bru_42_lau("LAU-3 Hydra M156 WP", 2, -1))   -- {LAU-3 Hydra M156 WP_TER_2_L}
+declare_loadout(bru_42_lau("LAU-3 Hydra M156 WP", 2, 1))    -- {LAU-3 Hydra M156 WP_TER_2_R}
 
 declare_loadout(bru_42_lau("LAU-68 FFAR WP156", 3, 0))      -- {LAU-68 FFAR WP156_TER_3_C}
 declare_loadout(bru_42_lau("LAU-68 FFAR WP156", 2, 0))      -- {LAU-68 FFAR WP156_TER_2_C}

--- a/A-4E-C/Weapons/A4E_Weapons.lua
+++ b/A-4E-C/Weapons/A4E_Weapons.lua
@@ -1750,7 +1750,7 @@ local rack_data = {
 
 local rocket_data = {
     ["LAU-3 Hydra M151 HE"]    = { name = "Hydra M151 HE",  mass = 100 + 19 * (23.6 * POUNDS_TO_KG),  wstype = {4,7,33,147}, payload_CLSID = "{LAU3_HE151}",                           shapename = "LAU-3",  pic = 'LAU61.png', count = 19, cx = 0.00146484375},
-    ["LAU-3 Hydra Mk5 HEAT"]   = { name = "Hydra M151 HE",  mass = 100 + 19 * (23.7 * POUNDS_TO_KG),  wstype = {4,7,33,147}, payload_CLSID = "{LAU3_HE5}",                             shapename = "LAU-3",  pic = 'LAU61.png', count = 19, cx = 0.00146484375},
+    ["LAU-3 Hydra Mk5 HEAT"]   = { name = "Hydra Mk5 HEAT", mass = 100 + 19 * (23.7 * POUNDS_TO_KG),  wstype = {4,7,33,147}, payload_CLSID = "{LAU3_HE5}",                             shapename = "LAU-3",  pic = 'LAU61.png', count = 19, cx = 0.00146484375},
     ["LAU-3 Hydra M156 WP"]    = { name = "Hydra M156 WP",  mass = 100 + 19 * (23.3 * POUNDS_TO_KG),  wstype = {4,7,33,147}, payload_CLSID = "{LAU3_WP156}",                           shapename = "LAU-3",  pic = 'LAU61.png', count = 19, cx = 0.00146484375},
 
     ["LAU-68 Hydra M151 HE"]   = { name = "Hydra M151 HE",  mass = 41.73 + 7 * (23.6 * POUNDS_TO_KG), wstype = {4,7,33,147}, payload_CLSID = "{A021F29D-18AB-4d3e-985C-FC9C60E35E9E}", shapename = "LAU-68", pic = 'LAU68.png', count = 7,  cx = 0.00146484375},
@@ -1761,9 +1761,11 @@ local rocket_data = {
     ["LAU-3 FFAR WP156"]       = { name = "FFAR M156 WP",   mass = 100 + 19 * (24.7 * POUNDS_TO_KG),  wstype = {4,7,33,147}, payload_CLSID = "{LAU3_FFAR_WP156}",                      shapename = "LAU-3",  pic = 'LAU61.png', count = 19, cx = 0.00146484375},
     ["LAU-3 FFAR Mk1 HE"]      = { name = "FFAR Mk1 HE",    mass = 100 + 19 * (21.5 * POUNDS_TO_KG),  wstype = {4,7,33,147}, payload_CLSID = "{LAU3_FFAR_MK1HE}",                      shapename = "LAU-3",  pic = 'LAU61.png', count = 19, cx = 0.00146484375},
     ["LAU-3 FFAR Mk5 HEAT"]    = { name = "FFAR Mk5 HEAT",  mass = 100 + 19 * (21.6 * POUNDS_TO_KG),  wstype = {4,7,33,147}, payload_CLSID = "{LAU3_FFAR_MK5HEAT}",                    shapename = "LAU-3",  pic = 'LAU61.png', count = 19, cx = 0.00146484375},
+
     ["LAU-68 FFAR WP156"]      = { name = "FFAR M156 WP",   mass = 41.73 + 7 * (24.7 * POUNDS_TO_KG), wstype = {4,7,33,147}, payload_CLSID = "{LAU68_FFAR_WP156}",                     shapename = "LAU-68", pic = 'LAU68.png', count = 7,  cx = 0.00146484375},
     ["LAU-68 FFAR Mk1 HE"]     = { name = "FFAR Mk1 HE",    mass = 41.73 + 7 * (21.5 * POUNDS_TO_KG), wstype = {4,7,33,147}, payload_CLSID = "{LAU68_FFAR_MK1HE}",                     shapename = "LAU-68", pic = 'LAU68.png', count = 7,  cx = 0.00146484375},
     ["LAU-68 FFAR Mk5 HEAT"]   = { name = "FFAR Mk5 HEAT",  mass = 41.73 + 7 * (21.6 * POUNDS_TO_KG), wstype = {4,7,33,147}, payload_CLSID = "{LAU68_FFAR_MK5HEAT}",                   shapename = "LAU-68", pic = 'LAU68.png', count = 7,  cx = 0.00146484375},
+
     ["LAU-10 ZUNI"]            = { name = "ZUNI MK 71",     mass = 440,                               wstype = {4,7,33,37},  payload_CLSID = "{F3EFE0AB-E91A-42D8-9CA2-B63C91ED570A}", shapename = "LAU-10", pic = 'LAU10.png', count = 4,  cx = 0.001708984375},
 }
 

--- a/A-4E-C/Weapons/A4E_Weapons.lua
+++ b/A-4E-C/Weapons/A4E_Weapons.lua
@@ -1725,8 +1725,7 @@ declare_loadout(CBU_DUMMY)
 --
 -- offset is the distance you'd have to move the model relative to origin to center the hangars about the origin, thus negative
 -- numbers are used to fix models where the origin is too far back.
-local bomb_data =
-{
+local bomb_data = {
     --use shapename,        mass,                   wstype,                             image,                 drag,                offset (m)
     --                                              volatile hardcoded values
     --                                              may need periodic updates
@@ -1744,21 +1743,27 @@ local bomb_data =
     ["BDU-33"]        = {   mass = 11.3         ,   wstype = {4,5,9,69},                pic = 'bdu-33.png',    cx = 0.00000143,     ofs = 0.0,      PictureBlendColor = false },
 }
 
-local rack_data =
-{
+local rack_data = {
     ["BRU_41"]          = {mass = 99.8, shapename = "mer_a4e", wstype = {4, 5, 32, WSTYPE_PLACEHOLDER} },
     ["BRU_42"]          = {mass = 47.6, shapename = "BRU_42A", wstype = {4, 5, 32, WSTYPE_PLACEHOLDER} },
 }
 
-local rocket_data = 
-{
-    ["LAU-3 FFAR WP156"]       = { name = "FFAR M156 WP", mass = 100 + 19 * (24.7 * POUNDS_TO_KG),  wstype = {4,7,33,147}, payload_CLSID = "{LAU3_FFAR_WP156}",                      shapename = "LAU-3",  pic = 'LAU61.png', count = 19, cx = 0.00146484375},
-    ["LAU-3 FFAR Mk1 HE"]      = { name = "FFAR Mk1 HE",  mass = 100 + 19 * (21.5 * POUNDS_TO_KG),  wstype = {4,7,33,147}, payload_CLSID = "{LAU3_FFAR_MK1HE}",                      shapename = "LAU-3",  pic = 'LAU61.png', count = 19, cx = 0.00146484375},
-    ["LAU-3 FFAR Mk5 HEAT"]    = { name = "FFAR Mk5 HEAT",mass = 100 + 19 * (21.6 * POUNDS_TO_KG),  wstype = {4,7,33,147}, payload_CLSID = "{LAU3_FFAR_MK5HEAT}",                    shapename = "LAU-3",  pic = 'LAU61.png', count = 19, cx = 0.00146484375},
-    ["LAU-68 FFAR WP156"]      = { name = "FFAR M156 WP", mass = 41.73 + 7 * (24.7 * POUNDS_TO_KG), wstype = {4,7,33,147}, payload_CLSID = "{LAU68_FFAR_WP156}",                     shapename = "LAU-68", pic = 'LAU68.png', count = 7,  cx = 0.00146484375},
-    ["LAU-68 FFAR Mk1 HE"]     = { name = "FFAR Mk1 HE",  mass = 41.73 + 7 * (21.5 * POUNDS_TO_KG), wstype = {4,7,33,147}, payload_CLSID = "{LAU68_FFAR_MK1HE}",                     shapename = "LAU-68", pic = 'LAU68.png', count = 7,  cx = 0.00146484375},
-    ["LAU-68 FFAR Mk5 HEAT"]   = { name = "FFAR Mk5 HEAT",mass = 41.73 + 7 * (21.6 * POUNDS_TO_KG), wstype = {4,7,33,147}, payload_CLSID = "{LAU68_FFAR_MK5HEAT}",                   shapename = "LAU-68", pic = 'LAU68.png', count = 7,  cx = 0.00146484375},
-    ["LAU-10 ZUNI"]            = { name = "ZUNI MK 71",   mass = 440,                               wstype = {4,7,33,37},  payload_CLSID = "{F3EFE0AB-E91A-42D8-9CA2-B63C91ED570A}", shapename = "LAU-10", pic = 'LAU10.png', count = 4,  cx = 0.001708984375},
+local rocket_data = {
+    ["LAU-61 Hydra M151 HE"]   = { name = "Hydra M151 HE",  mass = 100 + 19 * (23.6 * POUNDS_TO_KG),  wstype = {4,7,33,147}, payload_CLSID = "{FD90A1DC-9147-49FA-BF56-CB83EF0BD32B}", shapename = "LAU-61", pic = 'LAU61.png', count = 19, cx = 0.00146484375},
+    ["LAU-61 Hydra M156 WP"]   = { name = "Hydra M156 WP",  mass = 100 + 19 * (23.3 * POUNDS_TO_KG),  wstype = {4,7,33,147}, payload_CLSID = "{3DFB7321-AB0E-11d7-9897-000476191836}", shapename = "LAU-61", pic = 'LAU61.png', count = 19, cx = 0.00146484375},
+
+    ["LAU-68 Hydra M151 HE"]   = { name = "Hydra M151 HE",  mass = 41.73 + 7 * (23.6 * POUNDS_TO_KG), wstype = {4,7,33,147}, payload_CLSID = "{A021F29D-18AB-4d3e-985C-FC9C60E35E9E}", shapename = "LAU-68", pic = 'LAU68.png', count = 7,  cx = 0.00146484375},
+    ["LAU-68 Hydra Mk5 HEAT"]  = { name = "Hydra Mk5 HEAT", mass = 41.73 + 7 * (23.7 * POUNDS_TO_KG), wstype = {4,7,33,147}, payload_CLSID = "{174C6E6D-0C3D-42ff-BCB3-0853CB371F5C}", shapename = "LAU-68", pic = 'LAU68.png', count = 7,  cx = 0.00146484375},
+    ["LAU-68 Hydra M156 WP"]   = { name = "Hydra M156 WP",  mass = 41.73 + 7 * (23.3 * POUNDS_TO_KG), wstype = {4,7,33,147}, payload_CLSID = "{4F977A2A-CD25-44df-90EF-164BFA2AE72F}", shapename = "LAU-68", pic = 'LAU68.png', count = 7,  cx = 0.00146484375},
+    ["LAU-68 Hydra M257 PI"]   = { name = "Hydra M257 PI",  mass = 41.73 + 7 * (24.4 * POUNDS_TO_KG), wstype = {4,7,33,147}, payload_CLSID = "{647C5F26-BDD1-41e6-A371-8DE1E4CC0E94}", shapename = "LAU-68", pic = 'LAU68.png', count = 7,  cx = 0.00146484375},
+
+    ["LAU-3 FFAR WP156"]       = { name = "FFAR M156 WP",   mass = 100 + 19 * (24.7 * POUNDS_TO_KG),  wstype = {4,7,33,147}, payload_CLSID = "{LAU3_FFAR_WP156}",                      shapename = "LAU-3",  pic = 'LAU61.png', count = 19, cx = 0.00146484375},
+    ["LAU-3 FFAR Mk1 HE"]      = { name = "FFAR Mk1 HE",    mass = 100 + 19 * (21.5 * POUNDS_TO_KG),  wstype = {4,7,33,147}, payload_CLSID = "{LAU3_FFAR_MK1HE}",                      shapename = "LAU-3",  pic = 'LAU61.png', count = 19, cx = 0.00146484375},
+    ["LAU-3 FFAR Mk5 HEAT"]    = { name = "FFAR Mk5 HEAT",  mass = 100 + 19 * (21.6 * POUNDS_TO_KG),  wstype = {4,7,33,147}, payload_CLSID = "{LAU3_FFAR_MK5HEAT}",                    shapename = "LAU-3",  pic = 'LAU61.png', count = 19, cx = 0.00146484375},
+    ["LAU-68 FFAR WP156"]      = { name = "FFAR M156 WP",   mass = 41.73 + 7 * (24.7 * POUNDS_TO_KG), wstype = {4,7,33,147}, payload_CLSID = "{LAU68_FFAR_WP156}",                     shapename = "LAU-68", pic = 'LAU68.png', count = 7,  cx = 0.00146484375},
+    ["LAU-68 FFAR Mk1 HE"]     = { name = "FFAR Mk1 HE",    mass = 41.73 + 7 * (21.5 * POUNDS_TO_KG), wstype = {4,7,33,147}, payload_CLSID = "{LAU68_FFAR_MK1HE}",                     shapename = "LAU-68", pic = 'LAU68.png', count = 7,  cx = 0.00146484375},
+    ["LAU-68 FFAR Mk5 HEAT"]   = { name = "FFAR Mk5 HEAT",  mass = 41.73 + 7 * (21.6 * POUNDS_TO_KG), wstype = {4,7,33,147}, payload_CLSID = "{LAU68_FFAR_MK5HEAT}",                   shapename = "LAU-68", pic = 'LAU68.png', count = 7,  cx = 0.00146484375},
+    ["LAU-10 ZUNI"]            = { name = "ZUNI MK 71",     mass = 440,                               wstype = {4,7,33,37},  payload_CLSID = "{F3EFE0AB-E91A-42D8-9CA2-B63C91ED570A}", shapename = "LAU-10", pic = 'LAU10.png', count = 4,  cx = 0.001708984375},
 }
 
 local function bru_42_lau(element, count, side)
@@ -1961,8 +1966,7 @@ function bru_42(element,count,side) -- build a TER setup for the specified bombs
 end
 
 
-local dispenser_data =
-{
+local dispenser_data = {
     --use shapename,         bomblet,          bomblet_count
     ["CBU-1/A"]          = { bomblet = BLU_4B_NEW_GROUP, bomblet_count = 19, tube_size=tube_size_1A },
     ["CBU-2/A"]          = { bomblet = BLU_3B_NEW_GROUP, bomblet_count = 19, tube_size=tube_size_2A },
@@ -2041,42 +2045,70 @@ function make_cbu_a4e_multi(dispenser,count,side) -- assemble a rack of cluster 
     return data
 end
 
+declare_loadout(bru_42_lau("LAU-10 ZUNI", 3, 0))            -- {LAU-10 ZUNI_TER_3_C}
+declare_loadout(bru_42_lau("LAU-10 ZUNI", 2, 0))            -- {LAU-10 ZUNI_TER_2_C}
+declare_loadout(bru_42_lau("LAU-10 ZUNI", 2, -1))           -- {LAU-10 ZUNI_TER_2_L}
+declare_loadout(bru_42_lau("LAU-10 ZUNI", 2, 1))            -- {LAU-10 ZUNI_TER_2_R}
 
+declare_loadout(bru_42_lau("LAU-3 FFAR WP156", 3, 0))       -- {LAU-3 FFAR WP156_TER_3_C}
+declare_loadout(bru_42_lau("LAU-3 FFAR WP156", 2, 0))       -- {LAU-3 FFAR WP156_TER_2_C}
+declare_loadout(bru_42_lau("LAU-3 FFAR WP156", 2, -1))      -- {LAU-3 FFAR WP156_TER_2_L}
+declare_loadout(bru_42_lau("LAU-3 FFAR WP156", 2, 1))       -- {LAU-3 FFAR WP156_TER_2_R}
 
-declare_loadout(bru_42_lau("LAU-10 ZUNI", 3, 0))           -- {LAU-10 ZUNI_TER_3_C}
-declare_loadout(bru_42_lau("LAU-10 ZUNI", 2, 0))           -- {LAU-10 ZUNI_TER_2_C}
-declare_loadout(bru_42_lau("LAU-10 ZUNI", 2, -1))          -- {LAU-10 ZUNI_TER_2_L}
-declare_loadout(bru_42_lau("LAU-10 ZUNI", 2, 1))           -- {LAU-10 ZUNI_TER_2_R}
+declare_loadout(bru_42_lau("LAU-3 FFAR Mk1 HE", 3, 0))      -- {LAU-3 FFAR Mk1 HE_TER_3_C}
+declare_loadout(bru_42_lau("LAU-3 FFAR Mk1 HE", 2, 0))      -- {LAU-3 FFAR Mk1 HE_TER_2_C}
+declare_loadout(bru_42_lau("LAU-3 FFAR Mk1 HE", 2, -1))     -- {LAU-3 FFAR Mk1 HE_TER_2_L}
+declare_loadout(bru_42_lau("LAU-3 FFAR Mk1 HE", 2, 1))      -- {LAU-3 FFAR Mk1 HE_TER_2_R}
 
-declare_loadout(bru_42_lau("LAU-3 FFAR WP156", 3, 0))      -- {LAU-3 FFAR WP156_TER_3_C}
-declare_loadout(bru_42_lau("LAU-3 FFAR WP156", 2, 0))      -- {LAU-3 FFAR WP156_TER_2_C}
-declare_loadout(bru_42_lau("LAU-3 FFAR WP156", 2, -1))     -- {LAU-3 FFAR WP156_TER_2_L}
-declare_loadout(bru_42_lau("LAU-3 FFAR WP156", 2, 1))      -- {LAU-3 FFAR WP156_TER_2_R}
+declare_loadout(bru_42_lau("LAU-3 FFAR Mk5 HEAT", 3, 0))    -- {LAU-3 FFAR Mk5 HEAT_TER_3_C}
+declare_loadout(bru_42_lau("LAU-3 FFAR Mk5 HEAT", 2, 0))    -- {LAU-3 FFAR Mk5 HEAT_TER_2_C}
+declare_loadout(bru_42_lau("LAU-3 FFAR Mk5 HEAT", 2, -1))   -- {LAU-3 FFAR Mk5 HEAT_TER_2_L}
+declare_loadout(bru_42_lau("LAU-3 FFAR Mk5 HEAT", 2, 1))    -- {LAU-3 FFAR Mk5 HEAT_TER_2_R}
 
-declare_loadout(bru_42_lau("LAU-3 FFAR Mk1 HE", 3, 0))     -- {LAU-3 FFAR Mk1 HE_TER_3_C}
-declare_loadout(bru_42_lau("LAU-3 FFAR Mk1 HE", 2, 0))     -- {LAU-3 FFAR Mk1 HE_TER_2_C}
-declare_loadout(bru_42_lau("LAU-3 FFAR Mk1 HE", 2, -1))    -- {LAU-3 FFAR Mk1 HE_TER_2_L}
-declare_loadout(bru_42_lau("LAU-3 FFAR Mk1 HE", 2, 1))     -- {LAU-3 FFAR Mk1 HE_TER_2_R}
+declare_loadout(bru_42_lau("LAU-61 Hydra M151 HE", 3, 0))   -- {LAU-61 Hydra M151_TER_3_C}
+declare_loadout(bru_42_lau("LAU-61 Hydra M151 HE", 2, 0))   -- {LAU-61 Hydra M151_TER_2_C}
+declare_loadout(bru_42_lau("LAU-61 Hydra M151 HE", 2, -1))  -- {LAU-61 Hydra M151_TER_2_L}
+declare_loadout(bru_42_lau("LAU-61 Hydra M151 HE", 2, 1))   -- {LAU-61 Hydra M151_TER_2_R}
 
-declare_loadout(bru_42_lau("LAU-3 FFAR Mk5 HEAT", 3, 0))   -- {LAU-3 FFAR Mk5 HEAT_TER_3_C}
-declare_loadout(bru_42_lau("LAU-3 FFAR Mk5 HEAT", 2, 0))   -- {LAU-3 FFAR Mk5 HEAT_TER_2_C}
-declare_loadout(bru_42_lau("LAU-3 FFAR Mk5 HEAT", 2, -1))  -- {LAU-3 FFAR Mk5 HEAT_TER_2_L}
-declare_loadout(bru_42_lau("LAU-3 FFAR Mk5 HEAT", 2, 1))   -- {LAU-3 FFAR Mk5 HEAT_TER_2_R}
+declare_loadout(bru_42_lau("LAU-61 Hydra M156 WP", 3, 0))   -- {LAU-61 Hydra M156 WP_TER_3_C}
+declare_loadout(bru_42_lau("LAU-61 Hydra M156 WP", 2, 0))   -- {LAU-61 Hydra M156 WP_TER_2_C}
+declare_loadout(bru_42_lau("LAU-61 Hydra M156 WP", 2, -1))  -- {LAU-61 Hydra M156 WP_TER_2_L}
+declare_loadout(bru_42_lau("LAU-61 Hydra M156 WP", 2, 1))   -- {LAU-61 Hydra M156 WP_TER_2_R}
 
-declare_loadout(bru_42_lau("LAU-68 FFAR WP156", 3, 0))     -- {LAU-68 FFAR WP156_TER_3_C}
-declare_loadout(bru_42_lau("LAU-68 FFAR WP156", 2, 0))     -- {LAU-68 FFAR WP156_TER_2_C}
-declare_loadout(bru_42_lau("LAU-68 FFAR WP156", 2, -1))    -- {LAU-68 FFAR WP156_TER_2_L}
-declare_loadout(bru_42_lau("LAU-68 FFAR WP156", 2, 1))     -- {LAU-68 FFAR WP156_TER_2_R}
+declare_loadout(bru_42_lau("LAU-68 FFAR WP156", 3, 0))      -- {LAU-68 FFAR WP156_TER_3_C}
+declare_loadout(bru_42_lau("LAU-68 FFAR WP156", 2, 0))      -- {LAU-68 FFAR WP156_TER_2_C}
+declare_loadout(bru_42_lau("LAU-68 FFAR WP156", 2, -1))     -- {LAU-68 FFAR WP156_TER_2_L}
+declare_loadout(bru_42_lau("LAU-68 FFAR WP156", 2, 1))      -- {LAU-68 FFAR WP156_TER_2_R}
 
-declare_loadout(bru_42_lau("LAU-68 FFAR Mk1 HE", 3, 0))    -- {LAU-68 FFAR Mk1 HE_TER_3_C}
-declare_loadout(bru_42_lau("LAU-68 FFAR Mk1 HE", 2, 0))    -- {LAU-68 FFAR Mk1 HE_TER_2_C}
-declare_loadout(bru_42_lau("LAU-68 FFAR Mk1 HE", 2, -1))   -- {LAU-68 FFAR Mk1 HE_TER_2_L}
-declare_loadout(bru_42_lau("LAU-68 FFAR Mk1 HE", 2, 1))    -- {LAU-68 FFAR Mk1 HE_TER_2_R}
+declare_loadout(bru_42_lau("LAU-68 FFAR Mk1 HE", 3, 0))     -- {LAU-68 FFAR Mk1 HE_TER_3_C}
+declare_loadout(bru_42_lau("LAU-68 FFAR Mk1 HE", 2, 0))     -- {LAU-68 FFAR Mk1 HE_TER_2_C}
+declare_loadout(bru_42_lau("LAU-68 FFAR Mk1 HE", 2, -1))    -- {LAU-68 FFAR Mk1 HE_TER_2_L}
+declare_loadout(bru_42_lau("LAU-68 FFAR Mk1 HE", 2, 1))     -- {LAU-68 FFAR Mk1 HE_TER_2_R}
 
-declare_loadout(bru_42_lau("LAU-68 FFAR Mk5 HEAT", 3, 0))  -- {LAU-68 FFAR Mk5 HEAT_TER_3_C}
-declare_loadout(bru_42_lau("LAU-68 FFAR Mk5 HEAT", 2, 0))  -- {LAU-68 FFAR Mk5 HEAT_TER_2_C}
-declare_loadout(bru_42_lau("LAU-68 FFAR Mk5 HEAT", 2, -1)) -- {LAU-68 FFAR Mk5 HEAT_TER_2_L}
-declare_loadout(bru_42_lau("LAU-68 FFAR Mk5 HEAT", 2, 1))  -- {LAU-68 FFAR Mk5 HEAT_TER_2_R}
+declare_loadout(bru_42_lau("LAU-68 FFAR Mk5 HEAT", 3, 0))   -- {LAU-68 FFAR Mk5 HEAT_TER_3_C}
+declare_loadout(bru_42_lau("LAU-68 FFAR Mk5 HEAT", 2, 0))   -- {LAU-68 FFAR Mk5 HEAT_TER_2_C}
+declare_loadout(bru_42_lau("LAU-68 FFAR Mk5 HEAT", 2, -1))  -- {LAU-68 FFAR Mk5 HEAT_TER_2_L}
+declare_loadout(bru_42_lau("LAU-68 FFAR Mk5 HEAT", 2, 1))   -- {LAU-68 FFAR Mk5 HEAT_TER_2_R}
+
+declare_loadout(bru_42_lau("LAU-68 Hydra M156 WP", 3, 0))   -- {LAU-68 Hydra M156 WP_TER_3_C}
+declare_loadout(bru_42_lau("LAU-68 Hydra M156 WP", 2, 0))   -- {LAU-68 Hydra M156 WP_TER_2_C}
+declare_loadout(bru_42_lau("LAU-68 Hydra M156 WP", 2, -1))  -- {LAU-68 Hydra M156 WP_TER_2_L}
+declare_loadout(bru_42_lau("LAU-68 Hydra M156 WP", 2, 1))   -- {LAU-68 Hydra M156 WP_TER_2_R}
+
+declare_loadout(bru_42_lau("LAU-68 Hydra M151 HE", 3, 0))   -- {LAU-68 Hydra M151 HE_TER_3_C}
+declare_loadout(bru_42_lau("LAU-68 Hydra M151 HE", 2, 0))   -- {LAU-68 Hydra M151 HE_TER_2_C}
+declare_loadout(bru_42_lau("LAU-68 Hydra M151 HE", 2, -1))  -- {LAU-68 Hydra M151 HE_TER_2_L}
+declare_loadout(bru_42_lau("LAU-68 Hydra M151 HE", 2, 1))   -- {LAU-68 Hydra M151 HE_TER_2_R}
+
+declare_loadout(bru_42_lau("LAU-68 Hydra Mk5 HEAT", 3, 0))  -- {LAU-68 Hydra Mk5 HEAT_TER_3_C}
+declare_loadout(bru_42_lau("LAU-68 Hydra Mk5 HEAT", 2, 0))  -- {LAU-68 Hydra Mk5 HEAT_TER_2_C}
+declare_loadout(bru_42_lau("LAU-68 Hydra Mk5 HEAT", 2, -1)) -- {LAU-68 Hydra Mk5 HEAT_TER_2_L}
+declare_loadout(bru_42_lau("LAU-68 Hydra Mk5 HEAT", 2, 1))  -- {LAU-68 Hydra Mk5 HEAT_TER_2_R}
+
+declare_loadout(bru_42_lau("LAU-68 Hydra M257 PI", 3, 0))   -- {LAU-68 Hydra M257 PI_TER_3_C}
+declare_loadout(bru_42_lau("LAU-68 Hydra M257 PI", 2, 0))   -- {LAU-68 Hydra M257 PI_TER_2_C}
+declare_loadout(bru_42_lau("LAU-68 Hydra M257 PI", 2, -1))  -- {LAU-68 Hydra M257 PI_TER_2_L}
+declare_loadout(bru_42_lau("LAU-68 Hydra M257 PI", 2, 1))   -- {LAU-68 Hydra M257 PI_TER_2_R}
 
 declare_loadout(rackme_a4e("AN-M57", 6,  0))               -- {AN-M57_MER_6_C}
 declare_loadout(rackme_a4e("AN-M57", 5, -1))               -- {AN-M57_MER_5_L}

--- a/A-4E-C/Weapons/A4E_Weapons.lua
+++ b/A-4E-C/Weapons/A4E_Weapons.lua
@@ -1749,9 +1749,8 @@ local rack_data = {
 }
 
 local rocket_data = {
-    ["LAU-3 Hydra M151 HE"]    = { name = "Hydra M151 HE",  mass = 100 + 19 * (23.6 * POUNDS_TO_KG),  wstype = {4,7,33,147}, payload_CLSID = "{LAU3_HE151}",                           shapename = "LAU-3",  pic = 'LAU61.png', count = 19, cx = 0.00146484375},
-    ["LAU-3 Hydra Mk5 HEAT"]   = { name = "Hydra Mk5 HEAT", mass = 100 + 19 * (23.7 * POUNDS_TO_KG),  wstype = {4,7,33,147}, payload_CLSID = "{LAU3_HE5}",                             shapename = "LAU-3",  pic = 'LAU61.png', count = 19, cx = 0.00146484375},
-    ["LAU-3 Hydra M156 WP"]    = { name = "Hydra M156 WP",  mass = 100 + 19 * (23.3 * POUNDS_TO_KG),  wstype = {4,7,33,147}, payload_CLSID = "{LAU3_WP156}",                           shapename = "LAU-3",  pic = 'LAU61.png', count = 19, cx = 0.00146484375},
+    ["LAU-61 Hydra M151 HE"]   = { name = "Hydra M151 HE",  mass = 100 + 19 * (23.6 * POUNDS_TO_KG),  wstype = {4,7,33,147}, payload_CLSID = "{FD90A1DC-9147-49FA-BF56-CB83EF0BD32B}", shapename = "LAU-61", pic = 'LAU61.png', count = 19, cx = 0.00146484375},
+    ["LAU-61 Hydra M156 WP"]   = { name = "Hydra M156 WP",  mass = 100 + 19 * (23.3 * POUNDS_TO_KG),  wstype = {4,7,33,147}, payload_CLSID = "{3DFB7321-AB0E-11d7-9897-000476191836}", shapename = "LAU-61", pic = 'LAU61.png', count = 19, cx = 0.00146484375},
 
     ["LAU-68 Hydra M151 HE"]   = { name = "Hydra M151 HE",  mass = 41.73 + 7 * (23.6 * POUNDS_TO_KG), wstype = {4,7,33,147}, payload_CLSID = "{A021F29D-18AB-4d3e-985C-FC9C60E35E9E}", shapename = "LAU-68", pic = 'LAU68.png', count = 7,  cx = 0.00146484375},
     ["LAU-68 Hydra Mk5 HEAT"]  = { name = "Hydra Mk5 HEAT", mass = 41.73 + 7 * (23.7 * POUNDS_TO_KG), wstype = {4,7,33,147}, payload_CLSID = "{174C6E6D-0C3D-42ff-BCB3-0853CB371F5C}", shapename = "LAU-68", pic = 'LAU68.png', count = 7,  cx = 0.00146484375},
@@ -2068,20 +2067,15 @@ declare_loadout(bru_42_lau("LAU-3 FFAR Mk5 HEAT", 2, 0))    -- {LAU-3 FFAR Mk5 H
 declare_loadout(bru_42_lau("LAU-3 FFAR Mk5 HEAT", 2, -1))   -- {LAU-3 FFAR Mk5 HEAT_TER_2_L}
 declare_loadout(bru_42_lau("LAU-3 FFAR Mk5 HEAT", 2, 1))    -- {LAU-3 FFAR Mk5 HEAT_TER_2_R}
 
-declare_loadout(bru_42_lau("LAU-3 Hydra M151 HE", 3, 0))    -- {LAU-3 Hydra M151 HE_TER_3_C}
-declare_loadout(bru_42_lau("LAU-3 Hydra M151 HE", 2, 0))    -- {LAU-3 Hydra M151 HE_TER_2_C}
-declare_loadout(bru_42_lau("LAU-3 Hydra M151 HE", 2, -1))   -- {LAU-3 Hydra M151 HE_TER_2_L}
-declare_loadout(bru_42_lau("LAU-3 Hydra M151 HE", 2, 1))    -- {LAU-3 Hydra M151 HE_TER_2_R}
+declare_loadout(bru_42_lau("LAU-61 Hydra M151 HE", 3, 0))   -- {LAU-61 Hydra M151_TER_3_C}
+declare_loadout(bru_42_lau("LAU-61 Hydra M151 HE", 2, 0))   -- {LAU-61 Hydra M151_TER_2_C}
+declare_loadout(bru_42_lau("LAU-61 Hydra M151 HE", 2, -1))  -- {LAU-61 Hydra M151_TER_2_L}
+declare_loadout(bru_42_lau("LAU-61 Hydra M151 HE", 2, 1))   -- {LAU-61 Hydra M151_TER_2_R}
 
-declare_loadout(bru_42_lau("LAU-3 Hydra Mk5 HEAT", 3, 0))   -- {LAU-3 Hydra Mk5 HEAT_TER_3_C}
-declare_loadout(bru_42_lau("LAU-3 Hydra Mk5 HEAT", 2, 0))   -- {LAU-3 Hydra Mk5 HEAT_TER_2_C}
-declare_loadout(bru_42_lau("LAU-3 Hydra Mk5 HEAT", 2, -1))  -- {LAU-3 Hydra Mk5 HEAT_TER_2_L}
-declare_loadout(bru_42_lau("LAU-3 Hydra Mk5 HEAT", 2, 1))   -- {LAU-3 Hydra Mk5 HEAT_TER_2_R}
-
-declare_loadout(bru_42_lau("LAU-3 Hydra M156 WP", 3, 0))    -- {LAU-3 Hydra M156 WP_TER_3_C}
-declare_loadout(bru_42_lau("LAU-3 Hydra M156 WP", 2, 0))    -- {LAU-3 Hydra M156 WP_TER_2_C}
-declare_loadout(bru_42_lau("LAU-3 Hydra M156 WP", 2, -1))   -- {LAU-3 Hydra M156 WP_TER_2_L}
-declare_loadout(bru_42_lau("LAU-3 Hydra M156 WP", 2, 1))    -- {LAU-3 Hydra M156 WP_TER_2_R}
+declare_loadout(bru_42_lau("LAU-61 Hydra M156 WP", 3, 0))   -- {LAU-61 Hydra M156 WP_TER_3_C}
+declare_loadout(bru_42_lau("LAU-61 Hydra M156 WP", 2, 0))   -- {LAU-61 Hydra M156 WP_TER_2_C}
+declare_loadout(bru_42_lau("LAU-61 Hydra M156 WP", 2, -1))  -- {LAU-61 Hydra M156 WP_TER_2_L}
+declare_loadout(bru_42_lau("LAU-61 Hydra M156 WP", 2, 1))   -- {LAU-61 Hydra M156 WP_TER_2_R}
 
 declare_loadout(bru_42_lau("LAU-68 FFAR WP156", 3, 0))      -- {LAU-68 FFAR WP156_TER_3_C}
 declare_loadout(bru_42_lau("LAU-68 FFAR WP156", 2, 0))      -- {LAU-68 FFAR WP156_TER_2_C}

--- a/A-4E-C/Weapons/A4E_Weapons.lua
+++ b/A-4E-C/Weapons/A4E_Weapons.lua
@@ -1749,9 +1749,9 @@ local rack_data = {
 }
 
 local rocket_data = {
-    ["LAU-3 Hydra M151 HE"]   = { name = "Hydra M151 HE",  mass = 100 + 19 * (23.6 * POUNDS_TO_KG),  wstype = {4,7,33,147}, payload_CLSID = "{LAU3_HE151}",                            shapename = "LAU-3",  pic = 'LAU61.png', count = 19, cx = 0.00146484375},
-    ["LAU-3 Hydra Mk5 HEAT"]   = { name = "Hydra M151 HE",  mass = 100 + 19 * (23.7 * POUNDS_TO_KG), wstype = {4,7,33,147}, payload_CLSID = "{LAU3_HE5}",                              shapename = "LAU-3",  pic = 'LAU61.png', count = 19, cx = 0.00146484375},
-    ["LAU-3 Hydra M156 WP"]   = { name = "Hydra M156 WP",  mass = 100 + 19 * (23.3 * POUNDS_TO_KG),  wstype = {4,7,33,147}, payload_CLSID = "{LAU3_WP156}",                            shapename = "LAU-3",  pic = 'LAU61.png', count = 19, cx = 0.00146484375},
+    ["LAU-3 Hydra M151 HE"]    = { name = "Hydra M151 HE",  mass = 100 + 19 * (23.6 * POUNDS_TO_KG),  wstype = {4,7,33,147}, payload_CLSID = "{LAU3_HE151}",                           shapename = "LAU-3",  pic = 'LAU61.png', count = 19, cx = 0.00146484375},
+    ["LAU-3 Hydra Mk5 HEAT"]   = { name = "Hydra M151 HE",  mass = 100 + 19 * (23.7 * POUNDS_TO_KG),  wstype = {4,7,33,147}, payload_CLSID = "{LAU3_HE5}",                             shapename = "LAU-3",  pic = 'LAU61.png', count = 19, cx = 0.00146484375},
+    ["LAU-3 Hydra M156 WP"]    = { name = "Hydra M156 WP",  mass = 100 + 19 * (23.3 * POUNDS_TO_KG),  wstype = {4,7,33,147}, payload_CLSID = "{LAU3_WP156}",                           shapename = "LAU-3",  pic = 'LAU61.png', count = 19, cx = 0.00146484375},
 
     ["LAU-68 Hydra M151 HE"]   = { name = "Hydra M151 HE",  mass = 41.73 + 7 * (23.6 * POUNDS_TO_KG), wstype = {4,7,33,147}, payload_CLSID = "{A021F29D-18AB-4d3e-985C-FC9C60E35E9E}", shapename = "LAU-68", pic = 'LAU68.png', count = 7,  cx = 0.00146484375},
     ["LAU-68 Hydra Mk5 HEAT"]  = { name = "Hydra Mk5 HEAT", mass = 41.73 + 7 * (23.7 * POUNDS_TO_KG), wstype = {4,7,33,147}, payload_CLSID = "{174C6E6D-0C3D-42ff-BCB3-0853CB371F5C}", shapename = "LAU-68", pic = 'LAU68.png', count = 7,  cx = 0.00146484375},


### PR DESCRIPTION
- Add additions hydra rockets to all stations
- Missing the LAU-61 with 19x Hydra Mk5 HEAT, as I couldn't find a CLSID for them, so only HE and WP in the LAU-61 ~~switched to LAU-3 for the 19x pod~~ LAU-3 had problems, switched back to LAU-61 for now..
- Not tested by me, as editing `A-4E-C.lua` causees the EFM to fail.
- added to stores_config.lua for kneeboard